### PR TITLE
feat: add arm64 build

### DIFF
--- a/.github/workflows/push_branch-main_release.yml
+++ b/.github/workflows/push_branch-main_release.yml
@@ -80,6 +80,9 @@ jobs:
 
   build-container-image:
     needs: release
+    strategy:
+      matrix:
+        architecture: [amd64, arm64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout [${{ github.head_ref || github.ref_name }}]
@@ -114,6 +117,7 @@ jobs:
           mvn -B package -Pgithub -DskipTests
           -Dquarkus.container-image.build=true
           -Dquarkus.native.container-build=true -Dnative
+          -Dquarkus.jib.platforms=linux/${{ matrix.architecture }}
           -Dquarkus.container-image.additional-tags=${{ steps.version.outputs.TAG_MAJOR_MINOR }},${{ steps.version.outputs.TAG_MAJOR }}
           -Dquarkus.container-image.push=true
           -Dquarkus.container-image.registry=ghcr.io
@@ -125,6 +129,7 @@ jobs:
         run: >
           mvn -B package -Pgithub -DskipTests
           -Dquarkus.container-image.build=true
+          -Dquarkus.jib.platforms=linux/${{ matrix.architecture }}
           -Dquarkus.container-image.additional-tags=${{ steps.version.outputs.TAG_MAJOR_MINOR }},${{ steps.version.outputs.TAG_MAJOR }}
           -Dquarkus.container-image.push=true
           -Dquarkus.container-image.registry=ghcr.io


### PR DESCRIPTION
Couldn't test this in my fork, but I believe this should work to also build an arm64 container image.