### PR TITLE
fix(secrets): fix export for clients with overlapping naming and spec…

### DIFF
--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/boundary/ExportSecrets.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/boundary/ExportSecrets.java
@@ -6,76 +6,44 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
+
+import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.velocity.Template;
 import org.apache.velocity.runtime.parser.ParseException;
-import org.eclipse.microprofile.config.Config;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.ClientRepresentation;
 
+import com.cycrilabs.keycloak.configurator.commands.secrets.control.SecretFilesGenerator;
 import com.cycrilabs.keycloak.configurator.commands.secrets.entity.ExportSecretsCommandConfiguration;
 import com.cycrilabs.keycloak.configurator.shared.control.EnvironmentVariableProvider;
-import com.cycrilabs.keycloak.configurator.shared.control.StringUtil;
 import com.cycrilabs.keycloak.configurator.shared.control.VelocityUtils;
 
 import io.quarkus.logging.Log;
 
+@RequiredArgsConstructor
 @ApplicationScoped
 public class ExportSecrets {
-    private static final String VARIABLE_REALM = "realm";
-    private static final String VARIABLE_AUTH_SERVER_URL = "auth_server_url";
-    private static final String VARIABLE_CLIENT_ID = "client_id";
-    private static final String VARIABLE_CLIENT = "client";
-    private static final String VARIABLE_SECRET = "secret";
-    private static final String VARIABLE_CLIENTS = "clients";
-    private static final String VARIABLE_ENVIRONMENT = "env";
-
-    ExportSecretsCommandConfiguration configuration;
-    EnvironmentVariableProvider environmentVariableProvider;
-    Keycloak keycloak;
-    Config config;
-
-    @Inject
-    public ExportSecrets(
-            final ExportSecretsCommandConfiguration configuration,
-            final Keycloak keycloak,
-            final EnvironmentVariableProvider environmentVariableProvider,
-            final Config config
-    ) {
-        this.configuration = configuration;
-        this.keycloak = keycloak;
-        this.environmentVariableProvider = environmentVariableProvider;
-        this.config = config;
-    }
+    private final ExportSecretsCommandConfiguration configuration;
+    private final EnvironmentVariableProvider environmentVariableProvider;
+    private final Keycloak keycloak;
+    private final SecretFilesGenerator generator;
 
     public void export() throws IOException, ParseException {
         final Collection<Template> templates = VelocityUtils.loadTemplates(loadTemplateFiles());
         final Map<String, String> environmentVariables = environmentVariableProvider.load();
         final Map<String, ClientRepresentation> clients = loadClients();
-        final Collection<ClientRepresentation> filteredClients = getFilteredClients(clients);
-        for (final ClientRepresentation client : filteredClients) {
-            // skip all clients without a secret
-            if (StringUtil.isBlank(client.getSecret())) {
-                continue;
-            }
 
-            final Collection<Template> clientTemplates = deriveClientTemplates(client, templates);
-            for (final Template template : clientTemplates) {
-                Log.infof("Generating secret file(s) for client '%s'.", client.getClientId());
-                writeFiles(client, environmentVariables, clients, template);
-            }
-        }
+        generator.generateSecretFiles(configuration, templates, environmentVariables, clients,
+                (final String filename, final String fileContent) -> writeFiles(fileContent,
+                        getTargetPath(filename)));
     }
 
     private Collection<File> loadTemplateFiles() {
@@ -90,91 +58,15 @@ public class ExportSecrets {
                 .collect(Collectors.toMap(ClientRepresentation::getClientId, Function.identity()));
     }
 
-    private Collection<ClientRepresentation> getFilteredClients(
-            final Map<String, ClientRepresentation> clients) {
-        if (StringUtil.isBlank(configuration.getClientIds())) {
-            return clients.values();
-        }
-        final String[] split = configuration.getClientIds().split(",");
-        return Arrays.stream(split)
-                .map(clients::get)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+    private Path getTargetPath(final String filename) {
+        return Paths.get(configuration.getOutputDirectory(), filename);
     }
 
-    /**
-     * Derives all templates that must be expanded for the given client.
-     *
-     * @param client
-     *         the target client
-     * @param templates
-     *         all secret templates
-     * @return a list of relevant target secret templates for the given client
-     */
-    private Collection<Template> deriveClientTemplates(final ClientRepresentation client,
-            final Collection<Template> templates) {
-        final Map<String, Template> clientTemplates = new HashMap<>();
-        for (final Template template : templates) {
-            final String name = template.getName();
-            final String derivedName = getDerivedFilename(client.getClientId(), name);
-
-            // if the template is a generic one and there is no specialized entry at the moment
-            // it is added to the map
-            if (isGenericSecretTemplate(name) && !clientTemplates.containsKey(derivedName)) {
-                // we store the derived name temporarily to have it being overwritten by a more
-                // specific template
-                clientTemplates.put(derivedName, template);
-            }
-
-            // if the template contains the clientId in its name and is not generic
-            // it is always added to the map
-            // the generic check makes sure, there is no file that matches by accident with a client
-            if (!isGenericSecretTemplate(name) && name.contains(client.getClientId())) {
-                clientTemplates.put(name, template);
-            }
-        }
-        return clientTemplates.values();
-    }
-
-    private void writeFiles(final ClientRepresentation client,
-            final Map<String, String> environmentVariables,
-            final Map<String, ClientRepresentation> clients, final Template template) {
-        final String fileContent =
-                generateFileContent(client, environmentVariables, clients, template);
-        final Path targetFile = getTargetFile(client.getClientId(), template.getName());
+    private void writeFiles(final String fileContent, final Path targetFile) {
         try {
             Files.writeString(targetFile, fileContent, StandardCharsets.UTF_8);
         } catch (final IOException e) {
             Log.errorf("Failed to write file '%s'.", targetFile.toString());
         }
-    }
-
-    private String generateFileContent(final ClientRepresentation client,
-            final Map<String, String> environmentVariables,
-            final Map<String, ClientRepresentation> clients, final Template template) {
-        return VelocityUtils.mergeTemplate(template, VelocityUtils.createVelocityContext(
-                Map.ofEntries(
-                        Map.entry(VARIABLE_REALM, configuration.getRealmName()),
-                        Map.entry(VARIABLE_AUTH_SERVER_URL, configuration.getServer()),
-                        Map.entry(VARIABLE_CLIENT_ID, client.getClientId()),
-                        Map.entry(VARIABLE_CLIENT, client),
-                        Map.entry(VARIABLE_SECRET, client.getSecret()),
-                        Map.entry(VARIABLE_CLIENTS, clients),
-                        Map.entry(VARIABLE_ENVIRONMENT, environmentVariables)
-                )
-        ));
-    }
-
-    private Path getTargetFile(final String clientId, final String templateName) {
-        final String filename = getDerivedFilename(clientId, templateName);
-        return Paths.get(configuration.getOutputDirectory(), filename);
-    }
-
-    private String getDerivedFilename(final String clientId, final String templateName) {
-        return templateName.replace(VARIABLE_CLIENT_ID, clientId);
-    }
-
-    private boolean isGenericSecretTemplate(final String templateName) {
-        return templateName.contains(VARIABLE_CLIENT_ID);
     }
 }

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/control/SecretFileContentWriter.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/control/SecretFileContentWriter.java
@@ -1,0 +1,6 @@
+package com.cycrilabs.keycloak.configurator.commands.secrets.control;
+
+@FunctionalInterface
+public interface SecretFileContentWriter {
+    void provideContent(final String derivedFileName, final String fileContent);
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/control/SecretFilesGenerator.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/control/SecretFilesGenerator.java
@@ -1,0 +1,136 @@
+package com.cycrilabs.keycloak.configurator.commands.secrets.control;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.apache.velocity.Template;
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.secrets.entity.ExportSecretsCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.control.StringUtil;
+import com.cycrilabs.keycloak.configurator.shared.control.VelocityUtils;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class SecretFilesGenerator {
+    private static final String VARIABLE_REALM = "realm";
+    private static final String VARIABLE_AUTH_SERVER_URL = "auth_server_url";
+    private static final String VARIABLE_CLIENT_ID = "client_id";
+    private static final String VARIABLE_CLIENT = "client";
+    private static final String VARIABLE_SECRET = "secret";
+    private static final String VARIABLE_CLIENTS = "clients";
+    private static final String VARIABLE_ENVIRONMENT = "env";
+
+    private ExportSecretsCommandConfiguration configuration;
+    private Collection<Template> templates;
+    private Map<String, String> environmentVariables;
+    private Map<String, ClientRepresentation> clients;
+
+    public void generateSecretFiles(final ExportSecretsCommandConfiguration configuration,
+            final Collection<Template> templates, final Map<String, String> environmentVariables,
+            final Map<String, ClientRepresentation> clients,
+            final SecretFileContentWriter secretFileWriter) {
+        this.configuration = configuration;
+        this.templates = templates;
+        this.environmentVariables = environmentVariables;
+        this.clients = clients;
+
+        final Collection<ClientRepresentation> filteredClients = getFilteredClients();
+        for (final ClientRepresentation client : filteredClients) {
+            // skip all clients without a secret
+            if (StringUtil.isBlank(client.getSecret())) {
+                continue;
+            }
+
+            final Collection<Template> clientTemplates = deriveClientTemplates(client);
+            for (final Template template : clientTemplates) {
+                Log.infof("Generating secret file(s) for client '%s' based on '%s'.",
+                        client.getClientId(), template.getName());
+                final String fileContent = generateFileContent(client, template);
+                final String derivedName = getDerivedFilename(client, template);
+                secretFileWriter.provideContent(derivedName, fileContent);
+            }
+        }
+    }
+
+    private Collection<ClientRepresentation> getFilteredClients() {
+        final Stream<ClientRepresentation> filteredClients =
+                StringUtil.isBlank(configuration.getClientIds())
+                ? clients.values().stream()
+                : Arrays.stream(configuration.getClientIds().split(","))
+                        .map(clients::get)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet())
+                        .stream();
+        // clients are sorted by clientId to have a deterministic order;
+        // clients with short names are sorted first to have them in the top of the list and
+        // have the generated files being overwritten by more specific ones
+        return filteredClients
+                .sorted(Comparator.comparingInt(
+                                (ClientRepresentation c) -> c.getClientId().length())
+                        .thenComparing(ClientRepresentation::getClientId))
+                .toList();
+    }
+
+    /**
+     * Derives all templates that must be expanded for the given client.
+     *
+     * @param client
+     *         the target client
+     * @return a list of relevant target secret templates for the given client
+     */
+    private Collection<Template> deriveClientTemplates(final ClientRepresentation client) {
+        final Map<String, Template> clientTemplates = new HashMap<>();
+        for (final Template template : templates) {
+            final String name = template.getName();
+            final String derivedName = getDerivedFilename(client, template);
+
+            // if the template is a generic one and there is no specialized entry at the moment
+            // it is added to the map
+            if (isGenericSecretTemplate(name) && !clientTemplates.containsKey(derivedName)) {
+                // we store the derived name temporarily to have it being overwritten by a more
+                // specific template
+                clientTemplates.put(derivedName, template);
+            }
+
+            // if the template contains the clientId in its name and is not generic
+            // it is always added to the map
+            // the generic check makes sure, there is no file that matches by accident with a client
+            if (!isGenericSecretTemplate(name) && name.contains(client.getClientId())) {
+                clientTemplates.put(name, template);
+            }
+        }
+        return clientTemplates.values();
+    }
+
+    private String getDerivedFilename(final ClientRepresentation client, final Template template) {
+        return template.getName().replace(VARIABLE_CLIENT_ID, client.getClientId());
+    }
+
+    private boolean isGenericSecretTemplate(final String templateName) {
+        return templateName.contains(VARIABLE_CLIENT_ID);
+    }
+
+    private String generateFileContent(final ClientRepresentation client, final Template template) {
+        return VelocityUtils.mergeTemplate(template, VelocityUtils.createVelocityContext(
+                Map.ofEntries(
+                        Map.entry(VARIABLE_REALM, configuration.getRealmName()),
+                        Map.entry(VARIABLE_AUTH_SERVER_URL, configuration.getServer()),
+                        Map.entry(VARIABLE_CLIENT_ID, client.getClientId()),
+                        Map.entry(VARIABLE_CLIENT, client),
+                        Map.entry(VARIABLE_SECRET, client.getSecret()),
+                        Map.entry(VARIABLE_CLIENTS, clients),
+                        Map.entry(VARIABLE_ENVIRONMENT, environmentVariables)
+                )
+        ));
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/entity/ExportSecretsCommandConfiguration.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/secrets/entity/ExportSecretsCommandConfiguration.java
@@ -8,10 +8,14 @@ import picocli.CommandLine.ParseResult;
 
 @Getter
 public class ExportSecretsCommandConfiguration extends KeycloakConfiguration {
-    private final String realmName;
-    private final String configDirectory;
-    private final String clientIds;
-    private final String outputDirectory;
+    private String realmName;
+    private String configDirectory;
+    private String clientIds;
+    private String outputDirectory;
+
+    public ExportSecretsCommandConfiguration() {
+        // required to avoid "No default constructor for class" error
+    }
 
     public ExportSecretsCommandConfiguration(final ParseResult parseResult) {
         super(parseResult);

--- a/src/test/java/com/cycrilabs/keycloak/configurator/commands/configure/control/ConfigureCommandTest.java
+++ b/src/test/java/com/cycrilabs/keycloak/configurator/commands/configure/control/ConfigureCommandTest.java
@@ -1,7 +1,5 @@
 package com.cycrilabs.keycloak.configurator.commands.configure.control;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/cycrilabs/keycloak/configurator/commands/secrets/control/SecretFilesGeneratorTest.java
+++ b/src/test/java/com/cycrilabs/keycloak/configurator/commands/secrets/control/SecretFilesGeneratorTest.java
@@ -1,0 +1,232 @@
+package com.cycrilabs.keycloak.configurator.commands.secrets.control;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.runtime.parser.ParseException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.secrets.entity.ExportSecretsCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.control.JsonUtil;
+import com.cycrilabs.keycloak.configurator.shared.control.VelocityUtils;
+
+class SecretFilesGeneratorTest {
+    private SecretFilesGenerator sut;
+    private ExportSecretsCommandConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SecretFilesGenerator();
+        configuration = JsonUtil.fromJson("""
+                {
+                    "server": "http://localhost:8080",
+                    "username": "admin",
+                    "password": "admin",
+                    "realmName": "test-realm",
+                    "configDirectory": "/path/to/config",
+                    "clientIds": "",
+                    "outputDirectory": "/path/to/output"
+                }
+                """, ExportSecretsCommandConfiguration.class);
+    }
+
+    @Nested
+    class TemplateExportTests {
+        @Test
+        void shouldNotGenerateFiles_NoClientsGiven() {
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, null, Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    secretFiles::put);
+
+            Assertions.assertTrue(secretFiles.isEmpty());
+        }
+
+        @Test
+        void shouldNotGenerateFiles_NoTemplatesGiven() {
+            final Map<String, ClientRepresentation> clients = new HashMap<>();
+            clients.put("client1", new ClientRepresentation());
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, null, Collections.emptyMap(), clients,
+                    secretFiles::put);
+
+            Assertions.assertTrue(secretFiles.isEmpty());
+        }
+
+        @Test
+        void shouldGenerateFourFiles_TwoTemplatesGiven_TwoClientsGiven() throws ParseException {
+            final Map<String, ClientRepresentation> clients = new HashMap<>();
+            clients.put("client1", createClient("client1", "secret"));
+            clients.put("client2", createClient("client2", "my-secret"));
+            final Collection<Template> templates = new ArrayList<>();
+            templates.add(createTemplate("client_id.env", "CLIENT_ID=$client_id"));
+            templates.add(createTemplate("client_id.secret", "SECRET=$secret"));
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, templates, Collections.emptyMap(), clients,
+                    secretFiles::put);
+
+            Assertions.assertEquals(4, secretFiles.size());
+            Assertions.assertTrue(secretFiles.containsKey("client1.env"));
+            Assertions.assertTrue(secretFiles.containsKey("client1.secret"));
+            Assertions.assertTrue(secretFiles.containsKey("client2.env"));
+            Assertions.assertTrue(secretFiles.containsKey("client2.secret"));
+            Assertions.assertEquals("CLIENT_ID=client1", secretFiles.get("client1.env"));
+            Assertions.assertEquals("SECRET=secret", secretFiles.get("client1.secret"));
+            Assertions.assertEquals("CLIENT_ID=client2", secretFiles.get("client2.env"));
+            Assertions.assertEquals("SECRET=my-secret", secretFiles.get("client2.secret"));
+        }
+
+        @Test
+        void shouldGenerateFourFiles_ThreeTemplatesGiven_TwoClientsGiven_OneSpecificTemplate()
+                throws ParseException {
+            final Map<String, ClientRepresentation> clients = new HashMap<>();
+            clients.put("client1", createClient("client1", "secret"));
+            clients.put("client2", createClient("client2", "my-secret"));
+            final Collection<Template> templates = new ArrayList<>();
+            templates.add(createTemplate("client_id.env", "CLIENT_ID=$client_id"));
+            templates.add(createTemplate("client_id.secret", "SECRET=$secret"));
+            templates.add(createTemplate("client1.secret", "SPECIFIC_SECRET=$secret"));
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, templates, Collections.emptyMap(), clients,
+                    secretFiles::put);
+
+            Assertions.assertEquals(4, secretFiles.size());
+            Assertions.assertTrue(secretFiles.containsKey("client1.env"));
+            Assertions.assertTrue(secretFiles.containsKey("client1.secret"));
+            Assertions.assertTrue(secretFiles.containsKey("client2.env"));
+            Assertions.assertTrue(secretFiles.containsKey("client2.secret"));
+            Assertions.assertEquals("CLIENT_ID=client1", secretFiles.get("client1.env"));
+            Assertions.assertEquals("SPECIFIC_SECRET=secret", secretFiles.get("client1.secret"));
+            Assertions.assertEquals("CLIENT_ID=client2", secretFiles.get("client2.env"));
+            Assertions.assertEquals("SECRET=my-secret", secretFiles.get("client2.secret"));
+        }
+
+        @Test
+        void shouldUseCorrectClientForExport_ClientNamingIsOverlapping() throws ParseException {
+            final Map<String, ClientRepresentation> clients = new LinkedHashMap<>();
+            clients.put("eam-ui", createClient("eam-ui", "eam-ui"));
+            clients.put("eam", createClient("eam", "eam"));
+            final Collection<Template> templates = new ArrayList<>();
+            templates.add(createTemplate("eam-ui.secret", "SPECIFIC_SECRET=$secret"));
+            templates.add(createTemplate("client_id.secret", "SECRET=$secret"));
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, templates, Collections.emptyMap(), clients,
+                    secretFiles::put);
+
+            Assertions.assertEquals(2, secretFiles.size());
+            Assertions.assertTrue(secretFiles.containsKey("eam.secret"));
+            Assertions.assertTrue(secretFiles.containsKey("eam-ui.secret"));
+            Assertions.assertEquals("SECRET=eam", secretFiles.get("eam.secret"));
+            Assertions.assertEquals("SPECIFIC_SECRET=eam-ui", secretFiles.get("eam-ui.secret"));
+        }
+
+        @Test
+        void shouldExportClientsBasedOnFilter() throws ParseException {
+            final Map<String, ClientRepresentation> clients = new LinkedHashMap<>();
+            clients.put("eam-ui", createClient("eam-ui", "eam-ui"));
+            clients.put("eam", createClient("eam", "eam"));
+            final Collection<Template> templates = new ArrayList<>();
+            templates.add(createTemplate("client_id.secret", "SECRET=$secret"));
+
+            configuration = JsonUtil.fromJson("""
+                    {
+                        "server": "http://localhost:8080",
+                        "username": "admin",
+                        "password": "admin",
+                        "realmName": "test-realm",
+                        "configDirectory": "/path/to/config",
+                        "clientIds": "eam",
+                        "outputDirectory": "/path/to/output"
+                    }
+                    """, ExportSecretsCommandConfiguration.class);
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, templates, Collections.emptyMap(), clients,
+                    secretFiles::put);
+
+            Assertions.assertEquals(1, secretFiles.size());
+            Assertions.assertTrue(secretFiles.containsKey("eam.secret"));
+            Assertions.assertEquals("SECRET=eam", secretFiles.get("eam.secret"));
+        }
+    }
+
+    @Nested
+    class VariableInterpolationTests {
+        @Test
+        void shouldSupportClientDataInExport() throws ParseException {
+            final Map<String, ClientRepresentation> clients = new LinkedHashMap<>();
+            clients.put("eam", createClient("eam", "eam"));
+            final Collection<Template> templates = new ArrayList<>();
+            templates.add(createTemplate("client_id.secret", """
+                    SECRET=$secret
+                    CLIENT_ID=$client_id
+                    CLIENT_NAME=$client.name
+                    CLIENT_NAMES=$clients["eam"].name
+                    REALM=$realm
+                    AUTH_SERVER_URL=$auth_server_url
+                    """));
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, templates, Collections.emptyMap(), clients,
+                    secretFiles::put);
+
+            Assertions.assertEquals(1, secretFiles.size());
+            Assertions.assertTrue(secretFiles.containsKey("eam.secret"));
+            Assertions.assertEquals("""
+                    SECRET=eam
+                    CLIENT_ID=eam
+                    CLIENT_NAME=eam
+                    CLIENT_NAMES=eam
+                    REALM=test-realm
+                    AUTH_SERVER_URL=http://localhost:8080
+                    """, secretFiles.get("eam.secret"));
+        }
+
+        @Test
+        void shouldSupportEnvironmentVariablesInExport_KCCPrefixOnly() throws ParseException {
+            final Map<String, ClientRepresentation> clients = new LinkedHashMap<>();
+            clients.put("eam", createClient("eam", "eam"));
+            final Collection<Template> templates = new ArrayList<>();
+            templates.add(createTemplate("client_id.secret", """
+                    DATASOURCE_JDBC_URL=jdbc:postgresql://$env.KCC_DATABASE_NAME:5432
+                    """));
+            final Map<String, String> environmentVariables = new HashMap<>();
+            environmentVariables.put("KCC_DATABASE_NAME", "database");
+
+            final Map<String, String> secretFiles = new HashMap<>();
+            sut.generateSecretFiles(configuration, templates, environmentVariables, clients,
+                    secretFiles::put);
+
+            Assertions.assertEquals(1, secretFiles.size());
+            Assertions.assertTrue(secretFiles.containsKey("eam.secret"));
+            Assertions.assertEquals("""
+                    DATASOURCE_JDBC_URL=jdbc:postgresql://database:5432
+                    """, secretFiles.get("eam.secret"));
+        }
+    }
+
+    private ClientRepresentation createClient(final String clientId, final String secret) {
+        final ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(clientId);
+        client.setSecret(secret);
+        client.setName(clientId);
+        return client;
+    }
+
+    private Template createTemplate(final String name, final String content) throws ParseException {
+        return VelocityUtils.loadTemplateFromString(name, content);
+    }
+}


### PR DESCRIPTION
…ialized templates (#88)

If two clients share the same name, e.g. eam and eam-ui, and a specialized template is provided for eam-ui, then, depending on the order the clients are processed, the eam client is overwriting the exported file for the eam-ui client.

Fix by sorting the client based on their name. Like this, clients with short names are processed before. Clients with longer names will overwrite the previous files then.