### PR TITLE
feat(diff): report differences between server and local configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ realms, clients, client-roles, etc. represented by JSON files (configuration-as-
 In addition, it allows to __export secrets__ of all clients of a given realm based
 on a set of provided secret templates.
 Furthermore, it is possible to __export the configuration__ of Keycloak back to JSON
-files.
+files, and to __diff__ a Keycloak instance against the local configuration without
+modifying the server.
 
 All communication happens via the
 [Keycloak REST API](https://www.keycloak.org/docs-api/22.0.1/rest-api/index.html).
@@ -39,9 +40,10 @@ Previous to version 3.x, the Keycloak version itself is tracked:
 ## Usage
 
 The configurator prints out the help when executed with `-h` or `--help`. It
-lists all commands that are available. Currently, four commands are supported:
+lists all commands that are available. Currently, five commands are supported:
 
 * `configure` - Configures a Keycloak instance with a set of realms, clients, client-roles, etc.
+* `diff` - Reports all differences between a Keycloak instance and the local configuration
 * `export-secrets` - Exports secrets of all clients of the given realm
 * `rotate-secrets` - Rotates secrets of all clients of the given realm
 * `export-entities` - Exports entities of the given realm, optionally filtered by type or name
@@ -280,6 +282,62 @@ table lists all required and optional options of the `export-entities` sub-comma
 If no realm is provided, all realms are exported. If no client is provided, all clients
 of the given realm are exported. If no entity type is provided, all entity types are exported.
 If no entity name is provided, all entities of the given type are exported.
+
+### Sub-Command `diff`
+
+The `diff` sub-command reports all differences between a Keycloak instance and the local
+configuration. The server is only read and never modified, which makes the command usable
+as a drift check in a pipeline or as a preview before running `configure`.
+
+It reads the same configuration files as the `configure` sub-command and supports both the
+nested directory and the flat-file layout. The following table lists all required and
+optional options of the `diff` sub-command:
+
+| Option                  | Required | Description                                                                                              |
+|-------------------------|----------|----------------------------------------------------------------------------------------------------------|
+| `-s`, `--server`        | yes      | The URL of the Keycloak server.                                                                          |
+| `-u`, `--username`      | yes      | The username of the Keycloak admin user.                                                                 |
+| `-p`, `--password`      | yes      | The password of the Keycloak admin user. Can be omitted and read in via user input.                      |
+| `-c`, `--config`        | yes      | The path to the directory containing the configuration files.                                            |
+| `-t`, `--entity-type`   | no       | Allows to compare only one specific entity type.                                                         |
+| `--flat-files`          | no       | Reads configuration files from a flat file directory structure.                                          |
+| `--include-built-ins`   | no       | Also reports Keycloak built-in and auto-generated entities that are not configured locally.              |
+| `--ignore-extra`        | no       | An entity that must not be reported when it only exists on the server, e.g. `client:legacy-app`. Repeatable. |
+
+The command reports three kinds of differences:
+
+| Kind               | Meaning                                                                    |
+|--------------------|----------------------------------------------------------------------------|
+| `MISSING on server` | The entity is configured locally but does not exist on the server.        |
+| `~ <field>`        | The entity exists on both sides, but a locally declared field differs.      |
+| `EXTRA on server`  | The entity exists on the server but is not configured locally.              |
+
+For example:
+
+```
+=== realm-a ===
+  client 'blog'
+    ~ description: local="The blog" server="Blog"
+    ~ redirectUris: only in local: [https://blog.example/*]
+  client-role 'blog:posts-create'
+    MISSING on server
+  EXTRA on server: client 'legacy-app'
+
+3 differences across 3 entities in 1 realm(s). 14 entities checked.
+```
+
+The command returns the following exit codes, so that it can be used as a check:
+
+| Exit Code | Meaning                                                                  |
+|-----------|--------------------------------------------------------------------------|
+| `0`       | The server matches the local configuration.                              |
+| `1`       | Differences were found.                                                  |
+| `2`       | The command was called incorrectly.                                      |
+| `3`       | The server could not be reached, or it rejected the given credentials.    |
+
+Exit code `3` exists so that an unreachable server is not mistaken for a configuration that was
+never applied. The command authenticates before it compares anything, because otherwise every
+configured entity would be reported as missing on the server.
 
 ## Running via docker
 

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/boundary/AbstractImporter.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/boundary/AbstractImporter.java
@@ -1,11 +1,7 @@
 package com.cycrilabs.keycloak.configurator.commands.configure.boundary;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -13,8 +9,6 @@ import jakarta.ws.rs.core.Response;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.apache.velocity.Template;
-import org.apache.velocity.runtime.parser.ParseException;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.ErrorRepresentation;
 
@@ -24,37 +18,27 @@ import com.cycrilabs.keycloak.configurator.commands.configure.entity.Configurati
 import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigureCommandConfiguration;
 import com.cycrilabs.keycloak.configurator.commands.configure.entity.ImporterStatus;
 import com.cycrilabs.keycloak.configurator.shared.boundary.KeycloakCache;
-import com.cycrilabs.keycloak.configurator.shared.control.EnvironmentVariableProvider;
-import com.cycrilabs.keycloak.configurator.shared.control.JsonUtil;
-import com.cycrilabs.keycloak.configurator.shared.control.VelocityUtils;
+import com.cycrilabs.keycloak.configurator.shared.control.ConfigurationEntityLoader;
 import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.quarkus.logging.Log;
 
 public abstract class AbstractImporter<T> {
-    private static final String VARIABLE_ENVIRONMENT = "env";
-
     @Inject
     protected ConfigureCommandConfiguration configuration;
     @Inject
     protected ConfigurationFileStore configurationFileStore;
     @Inject
-    protected EnvironmentVariableProvider environmentVariableProvider;
+    protected ConfigurationEntityLoader entityLoader;
     @Inject
     protected KeycloakCache keycloakCache;
     @Inject
     protected Keycloak keycloak;
 
-    private Map<String, String> environmentVariables;
     @Getter
     @Setter
     private ImporterStatus status = ImporterStatus.NOT_STARTED;
-
-    @PostConstruct
-    public void init() {
-        environmentVariables = environmentVariableProvider.load();
-    }
 
     public void runImport() throws ConfigurationException {
         setStatus(ImporterStatus.STARTED);
@@ -139,23 +123,11 @@ public abstract class AbstractImporter<T> {
     }
 
     protected T loadEntity(final ConfigurationFile filepath, final Class<T> dtoClass) {
-        final String content = loadContent(filepath.getFile());
-        return JsonUtil.fromJson(content, dtoClass);
+        return entityLoader.loadEntity(filepath.getFile(), dtoClass);
     }
 
     protected T loadEntity(final ConfigurationFile filepath, final TypeReference<T> dtoType) {
-        final String content = loadContent(filepath.getFile());
-        return JsonUtil.fromJson(content, dtoType);
-    }
-
-    private String loadContent(final Path filepath) {
-        try {
-            final Template template = VelocityUtils.loadTemplate(filepath.toFile());
-            return VelocityUtils.mergeTemplate(template,
-                    Map.ofEntries(Map.entry(VARIABLE_ENVIRONMENT, environmentVariables)));
-        } catch (final IOException | ParseException e) {
-            throw new IllegalStateException(e);
-        }
+        return entityLoader.loadEntity(filepath.getFile(), dtoType);
     }
 
     public abstract EntityType getType();

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/CommandLineConfigurationSource.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/CommandLineConfigurationSource.java
@@ -1,0 +1,28 @@
+package com.cycrilabs.keycloak.configurator.commands.configure.control;
+
+import lombok.Getter;
+
+import com.cycrilabs.keycloak.configurator.shared.entity.ConfigurationSource;
+
+import picocli.CommandLine.ParseResult;
+
+/**
+ * A {@link ConfigurationSource} that reads its values directly from the parsed command line.
+ * This keeps the configuration file loading infrastructure independent of the invoked
+ * sub-command: every sub-command that reads configuration files declares the options
+ * {@code -c} and {@code --flat-files}, which is all that is required here.
+ */
+@Getter
+public class CommandLineConfigurationSource implements ConfigurationSource {
+    private final String configDirectory;
+    private final boolean flatFiles;
+
+    public CommandLineConfigurationSource(final ParseResult parseResult) {
+        configDirectory = getMatchedOption(parseResult, "-c");
+        flatFiles = this.<Boolean>getMatchedOption(parseResult, "--flat-files").booleanValue();
+    }
+
+    private <T> T getMatchedOption(final ParseResult parseResult, final String name) {
+        return parseResult.subcommand().commandSpec().optionsMap().get(name).getValue();
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/ConfigurationFileLoaderFactory.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/ConfigurationFileLoaderFactory.java
@@ -2,25 +2,33 @@ package com.cycrilabs.keycloak.configurator.commands.configure.control;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
 
-import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigureCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.entity.ConfigurationSource;
 
 import io.quarkus.logging.Log;
+import picocli.CommandLine;
 
 @ApplicationScoped
 public class ConfigurationFileLoaderFactory {
-    @Inject
-    ConfigureCommandConfiguration configuration;
-
+    /**
+     * Create the loader for the invoked sub-command. The configuration source is derived from
+     * the parsed command line instead of a concrete command configuration, so that every
+     * sub-command reading configuration files (e.g. 'configure' and 'diff') is served by this
+     * single producer.
+     *
+     * @param parseResult
+     *         the parsed command line
+     * @return the loader matching the requested configuration file layout
+     */
     @Produces
-    public ConfigurationFileLoader create() {
-        final ConfigurationFileLoader loader = createLoader();
+    public ConfigurationFileLoader create(final CommandLine.ParseResult parseResult) {
+        final ConfigurationFileLoader loader =
+                createLoader(new CommandLineConfigurationSource(parseResult));
         Log.infof("Using '%s'.", loader.getClass().getSimpleName());
         return loader;
     }
 
-    private ConfigurationFileLoader createLoader() {
+    private ConfigurationFileLoader createLoader(final ConfigurationSource configuration) {
         if (configuration.isFlatFiles()) {
             return new FlatFileConfigurationFileLoader(configuration);
         } else {

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/DirectoryConfigurationFileLoader.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/DirectoryConfigurationFileLoader.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
-import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigureCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.entity.ConfigurationSource;
 import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
 
 import io.quarkus.logging.Log;
@@ -56,10 +56,10 @@ import io.quarkus.logging.Log;
  * types.
  */
 public class DirectoryConfigurationFileLoader extends ConfigurationFileLoader {
-    private final ConfigureCommandConfiguration configuration;
+    private final ConfigurationSource configuration;
     private final Map<EntityType, List<ConfigurationFile>> configurationFiles = new HashMap<>();
 
-    public DirectoryConfigurationFileLoader(final ConfigureCommandConfiguration configuration) {
+    public DirectoryConfigurationFileLoader(final ConfigurationSource configuration) {
         this.configuration = configuration;
     }
 

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/FlatFileConfigurationFileLoader.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/control/FlatFileConfigurationFileLoader.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
-import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigureCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.entity.ConfigurationSource;
 import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
 
 import io.quarkus.logging.Log;
@@ -42,10 +42,10 @@ import io.quarkus.logging.Log;
 public class FlatFileConfigurationFileLoader extends ConfigurationFileLoader {
     private static final String TYPE_NAME_SEPARATOR = "_";
 
-    private final ConfigureCommandConfiguration configuration;
+    private final ConfigurationSource configuration;
     private final Map<EntityType, List<ConfigurationFile>> configurationFiles = new HashMap<>();
 
-    public FlatFileConfigurationFileLoader(final ConfigureCommandConfiguration configuration) {
+    public FlatFileConfigurationFileLoader(final ConfigurationSource configuration) {
         this.configuration = configuration;
     }
 

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/entity/ConfigureCommandConfiguration.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/configure/entity/ConfigureCommandConfiguration.java
@@ -2,13 +2,15 @@ package com.cycrilabs.keycloak.configurator.commands.configure.entity;
 
 import lombok.Getter;
 
+import com.cycrilabs.keycloak.configurator.shared.entity.ConfigurationSource;
 import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
 import com.cycrilabs.keycloak.configurator.shared.entity.KeycloakConfiguration;
 
 import picocli.CommandLine.ParseResult;
 
 @Getter
-public class ConfigureCommandConfiguration extends KeycloakConfiguration {
+public class ConfigureCommandConfiguration extends KeycloakConfiguration
+        implements ConfigurationSource {
     private final String configDirectory;
     private final EntityType entityType;
     private final boolean flatFiles;

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/AbstractDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/AbstractDiffer.java
@@ -1,0 +1,328 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.control.ConfigurationFileStore;
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.commands.diff.control.BuiltInEntityFilter;
+import com.cycrilabs.keycloak.configurator.commands.diff.control.ConfiguredRealms;
+import com.cycrilabs.keycloak.configurator.commands.diff.control.DiffReporter;
+import com.cycrilabs.keycloak.configurator.commands.diff.control.JsonDiffEngine;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.DiffCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.Difference;
+import com.cycrilabs.keycloak.configurator.shared.boundary.KeycloakCache;
+import com.cycrilabs.keycloak.configurator.shared.control.ConfigurationEntityLoader;
+import com.cycrilabs.keycloak.configurator.shared.control.JsonUtil;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+
+/**
+ * Compares all locally configured entities of one entity type against the server.
+ * <p>
+ * Differs are strictly read-only: they never create, update or delete anything on the server.
+ *
+ * @param <T>
+ *         the Keycloak representation type of the compared entity
+ */
+public abstract class AbstractDiffer<T> {
+    /**
+     * Identifiers that Keycloak generates. They never match a local configuration, and a
+     * configuration file exported from another server carries the identifiers of that server.
+     * Entities are matched by their name, so the identifiers carry no information for a
+     * comparison. This applies at any nesting depth, e.g. to protocol mappers as well.
+     */
+    private static final Set<String> GENERATED_IDENTIFIERS = Set.of("id", "containerId");
+
+    /**
+     * Fields that the server computes and that are never part of a configuration. 'access' holds
+     * the permissions the querying admin has on the entity, which says nothing about the entity
+     * itself.
+     */
+    private static final Set<String> SERVER_COMPUTED_FIELDS = Set.of("access");
+
+    @Inject
+    protected DiffCommandConfiguration configuration;
+    @Inject
+    protected ConfigurationFileStore configurationFileStore;
+    @Inject
+    protected ConfigurationEntityLoader entityLoader;
+    @Inject
+    protected KeycloakCache keycloakCache;
+    @Inject
+    protected Keycloak keycloak;
+    @Inject
+    protected DiffReporter reporter;
+    @Inject
+    protected BuiltInEntityFilter builtInEntityFilter;
+    @Inject
+    protected ConfiguredRealms configuredRealms;
+
+    /**
+     * The names of the locally configured entities per realm, collected while comparing them.
+     * Used to detect entities that only exist on the server.
+     */
+    private final Map<String, Set<String>> localEntityNames = new HashMap<>();
+
+    public void runDiff() {
+        if (configuration.getEntityType() != null && configuration.getEntityType() != getType()) {
+            Log.debugf("Skipping differ '%s' for entity type '%s'.", getClass().getSimpleName(),
+                    configuration.getEntityType());
+            return;
+        }
+
+        Log.infof("Executing differ '%s'.", getClass().getSimpleName());
+        for (final ConfigurationFile file : configurationFileStore.getImportFiles(getType())) {
+            try {
+                diffEntity(file);
+            } catch (final Exception e) {
+                Log.errorf("Could not compare file '%s' in differ '%s': %s", file.getFile(),
+                        getClass().getSimpleName(), e.getMessage());
+            }
+        }
+
+        try {
+            reportExtras();
+        } catch (final Exception e) {
+            Log.errorf("Could not determine entities missing locally in differ '%s': %s",
+                    getClass().getSimpleName(), e.getMessage());
+        }
+    }
+
+    /**
+     * Compares a single locally configured entity against its counterpart on the server.
+     *
+     * @param file
+     *         the configuration file of the entity
+     */
+    protected void diffEntity(final ConfigurationFile file) {
+        final T local = loadEntity(file);
+        final String realm = getRealmName(file, local);
+        final String entity = getEntityName(file, local);
+        rememberLocalEntity(realm, entity);
+        reporter.entityChecked();
+
+        // Without its realm an entity cannot exist either. Looking it up anyway would only
+        // produce a failing request per entity, while the realm is already reported as missing.
+        final T server = isRealmMissing(realm)
+                         ? null
+                         : findServerEntity(file, local);
+        if (server == null) {
+            reporter.add(Difference.missingOnServer(getType(), realm, entity));
+            return;
+        }
+
+        compare(realm, entity, local, normalizeServerEntity(server, file, local));
+    }
+
+    /**
+     * Compares the locally declared fields of an entity against the server and reports every
+     * difference.
+     *
+     * @param realm
+     *         the realm the entity belongs to
+     * @param entity
+     *         the identifying name of the entity
+     * @param local
+     *         the locally configured entity
+     * @param server
+     *         the entity as returned by the server
+     */
+    protected void compare(final String realm, final String entity, final Object local,
+            final Object server) {
+        JsonDiffEngine.compare(JsonUtil.toJsonNode(local), JsonUtil.toJsonNode(server),
+                getIgnoredPaths(),
+                field -> reporter.add(
+                        Difference.fieldDifferent(getType(), realm, entity, field)));
+    }
+
+    /**
+     * Reports all entities of this type that exist on the server but have no local configuration.
+     * Built-in and auto-generated entities are filtered out.
+     */
+    protected void reportExtras() {
+        for (final String realm : configuredRealms.get()) {
+            if (isRealmMissing(realm)) {
+                Log.debugf("Realm '%s' does not exist on the server, so it holds no entities.",
+                        realm);
+                continue;
+            }
+
+            final Set<String> configuredEntities =
+                    localEntityNames.getOrDefault(realm, Set.of());
+            for (final String serverEntity : getServerEntityNames(realm)) {
+                if (!configuredEntities.contains(serverEntity)) {
+                    reportExtra(realm, serverEntity);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reports a single entity that exists on the server but is not configured locally, unless it
+     * is a built-in entity.
+     *
+     * @param realm
+     *         the realm the entity belongs to
+     * @param entity
+     *         the identifying name of the entity
+     */
+    protected void reportExtra(final String realm, final String entity) {
+        if (builtInEntityFilter.isIgnored(getType(), realm, entity)) {
+            Log.debugf("Ignoring built-in %s '%s' of realm '%s'.", getType().getName(), entity,
+                    realm);
+            return;
+        }
+        reporter.add(Difference.extraOnServer(getType(), realm, entity));
+    }
+
+    /**
+     * The names of all entities of this type that exist in the given realm on the server.
+     * Differs that cannot enumerate their entities return an empty set.
+     *
+     * @param realm
+     *         the realm to enumerate
+     * @return the identifying names of all entities on the server
+     */
+    protected Set<String> getServerEntityNames(final String realm) {
+        return Set.of();
+    }
+
+    /**
+     * Adapts the server entity so that it can be compared to the local one, e.g. by resolving
+     * generated identifiers or by adding state that is served by a separate endpoint.
+     *
+     * @param server
+     *         the entity as returned by the server
+     * @param file
+     *         the configuration file of the entity
+     * @param local
+     *         the locally configured entity
+     * @return the entity to compare against
+     */
+    protected T normalizeServerEntity(final T server, final ConfigurationFile file, final T local) {
+        return server;
+    }
+
+    /**
+     * Field paths that must not be compared because both sides cannot be compared meaningfully.
+     * An entry matches either the full path of a field or its name at any depth.
+     *
+     * @return the ignored field paths
+     */
+    protected Set<String> getIgnoredPaths() {
+        final Set<String> ignoredPaths = new HashSet<>(GENERATED_IDENTIFIERS);
+        ignoredPaths.addAll(SERVER_COMPUTED_FIELDS);
+        return ignoredPaths;
+    }
+
+    /**
+     * The realm of the entity. Taken from the configuration file by default.
+     *
+     * @param file
+     *         the configuration file of the entity
+     * @param local
+     *         the locally configured entity
+     * @return the realm name
+     */
+    protected String getRealmName(final ConfigurationFile file, final T local) {
+        return file.getRealmName();
+    }
+
+    /**
+     * Whether the given realm does not exist on the server.
+     *
+     * @param realm
+     *         the realm to check
+     * @return true if the realm is not present on the server
+     */
+    private boolean isRealmMissing(final String realm) {
+        return realm != null && keycloakCache.getRealmByName(realm) == null;
+    }
+
+    private void rememberLocalEntity(final String realm, final String entity) {
+        localEntityNames.computeIfAbsent(realm, key -> new HashSet<>()).add(entity);
+    }
+
+    /**
+     * The names of all locally configured entities of this type in the given realm.
+     *
+     * @param realm
+     *         the realm to look up
+     * @return the locally configured entity names
+     */
+    protected Set<String> getLocalEntityNames(final String realm) {
+        return localEntityNames.getOrDefault(realm, Set.of());
+    }
+
+    /**
+     * Looks up a user by an exact username match, as the importers do. The fuzzy search of the
+     * Keycloak cache matches substrings of several fields and could return a different user.
+     *
+     * @param realm
+     *         the realm of the user
+     * @param username
+     *         the username to look up
+     * @return the user, or null if no unique user was found
+     */
+    protected UserRepresentation findUserByExactUsername(final String realm,
+            final String username) {
+        final List<UserRepresentation> users =
+                keycloak.realm(realm).users().searchByUsername(username, Boolean.TRUE);
+        if (users.size() == 1) {
+            return users.getFirst();
+        }
+
+        if (!users.isEmpty()) {
+            Log.warnf("Found %d users '%s' in realm '%s'. Skipping comparison.",
+                    Integer.valueOf(users.size()), username, realm);
+        }
+        return null;
+    }
+
+    public int getPriority() {
+        return getType().getPriority();
+    }
+
+    public abstract EntityType getType();
+
+    /**
+     * Loads the entity from its configuration file.
+     *
+     * @param file
+     *         the configuration file of the entity
+     * @return the locally configured entity
+     */
+    protected abstract T loadEntity(final ConfigurationFile file);
+
+    /**
+     * Looks up the entity on the server.
+     *
+     * @param file
+     *         the configuration file of the entity
+     * @param local
+     *         the locally configured entity
+     * @return the entity on the server, or null if it does not exist
+     */
+    protected abstract T findServerEntity(final ConfigurationFile file, final T local);
+
+    /**
+     * The identifying name of the entity as it is shown in the report.
+     *
+     * @param file
+     *         the configuration file of the entity
+     * @param local
+     *         the locally configured entity
+     * @return the identifying name
+     */
+    protected abstract String getEntityName(final ConfigurationFile file, final T local);
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ClientDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ClientDiffer.java
@@ -1,0 +1,111 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+@ApplicationScoped
+public class ClientDiffer extends AbstractDiffer<ClientRepresentation> {
+    @Override
+    public EntityType getType() {
+        return EntityType.CLIENT;
+    }
+
+    @Override
+    protected ClientRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), ClientRepresentation.class);
+    }
+
+    @Override
+    protected ClientRepresentation findServerEntity(final ConfigurationFile file,
+            final ClientRepresentation local) {
+        return keycloakCache.getClientByClientId(file.getRealmName(), local.getClientId());
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file,
+            final ClientRepresentation local) {
+        return local.getClientId();
+    }
+
+    @Override
+    protected Set<String> getIgnoredPaths() {
+        final Set<String> ignoredPaths = new HashSet<>(super.getIgnoredPaths());
+        // Issued by the server when the client is created.
+        ignoredPaths.add("registrationAccessToken");
+        // Stamped by the server when the client secret is created.
+        ignoredPaths.add("attributes.client.secret.creation.time");
+        return ignoredPaths;
+    }
+
+    /**
+     * The assigned client scopes are served by separate endpoints and are not part of the client
+     * representation, although they can be declared when a client is created. They are added here
+     * so that locally declared scopes can be compared instead of being reported as not set on the
+     * server.
+     */
+    @Override
+    protected ClientRepresentation normalizeServerEntity(final ClientRepresentation server,
+            final ConfigurationFile file, final ClientRepresentation local) {
+        if (local.getDefaultClientScopes() == null && local.getOptionalClientScopes() == null) {
+            return server;
+        }
+
+        final String realm = file.getRealmName();
+        final ClientResource clientResource =
+                keycloak.realm(realm).clients().get(server.getId());
+        if (local.getDefaultClientScopes() != null) {
+            server.setDefaultClientScopes(assignedScopes(realm,
+                    clientResource.getDefaultClientScopes(), local.getDefaultClientScopes()));
+        }
+        if (local.getOptionalClientScopes() != null) {
+            server.setOptionalClientScopes(assignedScopes(realm,
+                    clientResource.getOptionalClientScopes(), local.getOptionalClientScopes()));
+        }
+        return server;
+    }
+
+    /**
+     * The scopes assigned on the server, without the built-in scopes that Keycloak assigns on its
+     * own. Enabling service accounts for instance adds the 'service_account' scope, which would
+     * otherwise be reported for every client. Built-in scopes that the configuration does declare
+     * stay in the comparison.
+     *
+     * @param realm
+     *         the realm of the client
+     * @param assignedScopes
+     *         the scopes assigned on the server
+     * @param declaredScopes
+     *         the scopes declared by the local configuration
+     * @return the scope names to compare against
+     */
+    private List<String> assignedScopes(final String realm,
+            final List<ClientScopeRepresentation> assignedScopes,
+            final List<String> declaredScopes) {
+        return assignedScopes.stream()
+                .map(ClientScopeRepresentation::getName)
+                .filter(scope -> declaredScopes.contains(scope)
+                        || !builtInEntityFilter.isIgnored(EntityType.CLIENT_SCOPE, realm, scope))
+                .toList();
+    }
+
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        return keycloak.realm(realm)
+                .clients()
+                .findAll()
+                .stream()
+                .map(ClientRepresentation::getClientId)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ClientRoleDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ClientRoleDiffer.java
@@ -1,0 +1,96 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class ClientRoleDiffer extends AbstractDiffer<RoleRepresentation> {
+    private static final String CLIENT_ROLE_SEPARATOR = ":";
+
+    @Override
+    public EntityType getType() {
+        return EntityType.CLIENT_ROLE;
+    }
+
+    @Override
+    protected RoleRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), RoleRepresentation.class);
+    }
+
+    @Override
+    protected RoleRepresentation findServerEntity(final ConfigurationFile file,
+            final RoleRepresentation local) {
+        return keycloakCache.getClientRoleByName(file.getRealmName(), file.getClientId(),
+                local.getName());
+    }
+
+    /**
+     * A client role is only unique within its client, so the owning client is part of the name.
+     */
+    @Override
+    protected String getEntityName(final ConfigurationFile file, final RoleRepresentation local) {
+        return file.getClientId() + CLIENT_ROLE_SEPARATOR + local.getName();
+    }
+
+    @Override
+    protected Set<String> getIgnoredPaths() {
+        final Set<String> ignoredPaths = new HashSet<>(super.getIgnoredPaths());
+        // Composite role membership is served by a separate endpoint and is not applied by the
+        // 'configure' command either, so it is out of scope for the comparison.
+        ignoredPaths.add("composites");
+        return ignoredPaths;
+    }
+
+    /**
+     * Roles are only enumerated for clients that have locally configured roles. Without this
+     * restriction every role of every client of the realm would be reported, which says nothing
+     * about a configuration that does not manage that client's roles at all.
+     */
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        final Set<String> serverRoles = new LinkedHashSet<>();
+        for (final String clientId : getConfiguredClientIds(realm)) {
+            final ClientRepresentation client = keycloakCache.getClientByClientId(realm, clientId);
+            if (client == null) {
+                Log.debugf("Skipping client roles of unknown client '%s' in realm '%s'.", clientId,
+                        realm);
+                continue;
+            }
+
+            keycloak.realm(realm)
+                    .clients()
+                    .get(client.getId())
+                    .roles()
+                    .list()
+                    .forEach(role -> serverRoles.add(
+                            clientId + CLIENT_ROLE_SEPARATOR + role.getName()));
+        }
+        return serverRoles;
+    }
+
+    /**
+     * The clients that have at least one locally configured role, derived from the names of the
+     * compared entities.
+     *
+     * @param realm
+     *         the realm to look up
+     * @return the client ids with locally configured roles
+     */
+    private Set<String> getConfiguredClientIds(final String realm) {
+        return getLocalEntityNames(realm).stream()
+                .map(entity -> entity.substring(0, entity.indexOf(CLIENT_ROLE_SEPARATOR)))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ClientScopeDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ClientScopeDiffer.java
@@ -1,0 +1,46 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+@ApplicationScoped
+public class ClientScopeDiffer extends AbstractDiffer<ClientScopeRepresentation> {
+    @Override
+    public EntityType getType() {
+        return EntityType.CLIENT_SCOPE;
+    }
+
+    @Override
+    protected ClientScopeRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), ClientScopeRepresentation.class);
+    }
+
+    @Override
+    protected ClientScopeRepresentation findServerEntity(final ConfigurationFile file,
+            final ClientScopeRepresentation local) {
+        return keycloakCache.getClientScopeByName(file.getRealmName(), local.getName());
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file,
+            final ClientScopeRepresentation local) {
+        return local.getName();
+    }
+
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        return keycloak.realm(realm)
+                .clientScopes()
+                .findAll()
+                .stream()
+                .map(ClientScopeRepresentation::getName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ComponentDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ComponentDiffer.java
@@ -1,0 +1,157 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class ComponentDiffer extends AbstractDiffer<ComponentRepresentation> {
+    /**
+     * The parent components referenced by the local configuration. Sub components are only
+     * enumerated below these parents, because creating a component provider such as an LDAP
+     * provider makes Keycloak create a whole set of sub components on its own.
+     */
+    private final Set<String> locallyReferencedParents = new LinkedHashSet<>();
+
+    @Override
+    public EntityType getType() {
+        return EntityType.COMPONENT;
+    }
+
+    @Override
+    protected ComponentRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), ComponentRepresentation.class);
+    }
+
+    /**
+     * Looks up the component below the parent that the local configuration declares. Like the
+     * importer, the local 'parentId' is interpreted as the name of the parent component, and an
+     * absent parent means the component belongs to the realm itself.
+     */
+    @Override
+    protected ComponentRepresentation findServerEntity(final ConfigurationFile file,
+            final ComponentRepresentation local) {
+        final String realm = file.getRealmName();
+        if (local.getParentId() != null) {
+            locallyReferencedParents.add(local.getParentId());
+        }
+
+        final String parentId = resolveParentId(realm, local.getParentId());
+        if (parentId == null) {
+            Log.debugf("Parent '%s' of component '%s' does not exist in realm '%s'.",
+                    local.getParentId(), local.getName(), realm);
+            return null;
+        }
+        return findComponentByName(realm, parentId, local.getName());
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file,
+            final ComponentRepresentation local) {
+        return local.getName();
+    }
+
+    /**
+     * The local configuration references the parent by name while the server reports its
+     * generated identifier, so the server value is translated back to the parent's name.
+     */
+    @Override
+    protected ComponentRepresentation normalizeServerEntity(final ComponentRepresentation server,
+            final ConfigurationFile file, final ComponentRepresentation local) {
+        final String realm = file.getRealmName();
+        if (local.getParentId() == null || server.getParentId() == null
+                || server.getParentId().equals(getRealmId(realm))) {
+            return server;
+        }
+
+        try {
+            final ComponentRepresentation parent = keycloak.realm(realm)
+                    .components()
+                    .component(server.getParentId())
+                    .toRepresentation();
+            server.setParentId(parent.getName());
+        } catch (final RuntimeException e) {
+            Log.debugf("Could not resolve the parent of component '%s' in realm '%s': %s",
+                    local.getName(), realm, e.getMessage());
+        }
+        return server;
+    }
+
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        final String realmId = getRealmId(realm);
+        if (realmId == null) {
+            return Set.of();
+        }
+
+        final Set<String> names = new LinkedHashSet<>(getComponentNames(realm, realmId));
+        for (final String parentName : locallyReferencedParents) {
+            final ComponentRepresentation parent = findComponentByName(realm, realmId, parentName);
+            if (parent != null) {
+                names.addAll(getComponentNames(realm, parent.getId()));
+            }
+        }
+        return names;
+    }
+
+    private Set<String> getComponentNames(final String realm, final String parentId) {
+        return keycloak.realm(realm)
+                .components()
+                .query(parentId)
+                .stream()
+                .filter(component -> !builtInEntityFilter.isBuiltInComponentProviderType(
+                        component.getProviderType()))
+                .map(ComponentRepresentation::getName)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Resolves the identifier of the parent a component belongs to.
+     *
+     * @param realm
+     *         the realm of the component
+     * @param localParentName
+     *         the parent as declared locally, or null if the component belongs to the realm
+     * @return the identifier of the parent, or null if the declared parent does not exist
+     */
+    private String resolveParentId(final String realm, final String localParentName) {
+        final String realmId = getRealmId(realm);
+        if (localParentName == null || localParentName.equals(realmId)) {
+            return realmId;
+        }
+
+        final ComponentRepresentation parent =
+                findComponentByName(realm, realmId, localParentName);
+        return parent == null
+               ? null
+               : parent.getId();
+    }
+
+    private ComponentRepresentation findComponentByName(final String realm, final String parentId,
+            final String name) {
+        return keycloak.realm(realm)
+                .components()
+                .query(parentId)
+                .stream()
+                .filter(component -> name.equals(component.getName()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String getRealmId(final String realm) {
+        final RealmRepresentation realmRepresentation = keycloakCache.getRealmByName(realm);
+        return realmRepresentation == null
+               ? null
+               : realmRepresentation.getId();
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/GroupDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/GroupDiffer.java
@@ -1,0 +1,120 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.NotFoundException;
+
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class GroupDiffer extends AbstractDiffer<GroupRepresentation> {
+    @Override
+    public EntityType getType() {
+        return EntityType.GROUP;
+    }
+
+    @Override
+    protected GroupRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), GroupRepresentation.class);
+    }
+
+    @Override
+    protected GroupRepresentation findServerEntity(final ConfigurationFile file,
+            final GroupRepresentation local) {
+        return findGroupByPath(file.getRealmName(), local.getPath());
+    }
+
+    /**
+     * Groups are identified by their path, so that groups of the same name below different
+     * parents are distinguished.
+     */
+    @Override
+    protected String getEntityName(final ConfigurationFile file, final GroupRepresentation local) {
+        return local.getPath();
+    }
+
+    /**
+     * The realm roles of a group are served by a separate endpoint and are not part of the group
+     * representation. They are added here so that a locally declared 'realmRoles' can be
+     * compared at all.
+     */
+    @Override
+    protected GroupRepresentation normalizeServerEntity(final GroupRepresentation server,
+            final ConfigurationFile file, final GroupRepresentation local) {
+        if (local.getRealmRoles() == null) {
+            return server;
+        }
+
+        server.setRealmRoles(keycloak.realm(file.getRealmName())
+                .groups()
+                .group(server.getId())
+                .roles()
+                .realmLevel()
+                .listAll()
+                .stream()
+                .map(RoleRepresentation::getName)
+                .toList());
+        return server;
+    }
+
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        final Set<String> paths = new LinkedHashSet<>();
+        collectPaths(realm, keycloak.realm(realm).groups().groups(), paths);
+        return paths;
+    }
+
+    /**
+     * Collects the paths of the given groups and of all their descendants.
+     *
+     * @param realm
+     *         the realm the groups belong to
+     * @param groups
+     *         the groups to collect
+     * @param paths
+     *         collects the resulting paths
+     */
+    private void collectPaths(final String realm, final List<GroupRepresentation> groups,
+            final Set<String> paths) {
+        for (final GroupRepresentation group : groups) {
+            paths.add(group.getPath());
+            collectPaths(realm, getSubGroups(realm, group), paths);
+        }
+    }
+
+    private List<GroupRepresentation> getSubGroups(final String realm,
+            final GroupRepresentation group) {
+        try {
+            return keycloak.realm(realm)
+                    .groups()
+                    .group(group.getId())
+                    .getSubGroups(null, null, Boolean.TRUE);
+        } catch (final RuntimeException e) {
+            Log.debugf("Could not read sub groups of group '%s' in realm '%s': %s", group.getPath(),
+                    realm, e.getMessage());
+            return List.of();
+        }
+    }
+
+    private GroupRepresentation findGroupByPath(final String realm, final String path) {
+        if (path == null) {
+            Log.warnf("Cannot look up a group without a path in realm '%s'.", realm);
+            return null;
+        }
+
+        try {
+            return keycloak.realm(realm).getGroupByPath(path);
+        } catch (final NotFoundException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/RealmDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/RealmDiffer.java
@@ -1,0 +1,93 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.RealmRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+@ApplicationScoped
+public class RealmDiffer extends AbstractDiffer<RealmRepresentation> {
+    /**
+     * Collections that the realm endpoint does not serve. They are either part of a full realm
+     * export only, or they are reported by the differ of their own entity type. Comparing them
+     * against the realm representation would report every entity as missing on the server.
+     */
+    private static final Set<String> COLLECTIONS_NOT_SERVED_BY_REALM_ENDPOINT = Set.of(
+            "clients",
+            "clientScopes",
+            "clientTemplates",
+            "roles",
+            "groups",
+            "users",
+            "federatedUsers",
+            "components",
+            "applications",
+            "oauthClients",
+            "authenticationFlows",
+            "authenticatorConfig",
+            "requiredActions",
+            "scopeMappings",
+            "clientScopeMappings",
+            "protocolMappers",
+            "identityProviders",
+            "identityProviderMappers",
+            "clientProfiles",
+            "clientPolicies");
+
+    @Override
+    public EntityType getType() {
+        return EntityType.REALM;
+    }
+
+    @Override
+    protected RealmRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), RealmRepresentation.class);
+    }
+
+    @Override
+    protected RealmRepresentation findServerEntity(final ConfigurationFile file,
+            final RealmRepresentation local) {
+        return keycloakCache.getRealmByName(local.getRealm());
+    }
+
+    /**
+     * The realm of a realm entity is the realm itself. It is read from the file content, because
+     * realm files carry no realm name when read from a nested directory structure.
+     */
+    @Override
+    protected String getRealmName(final ConfigurationFile file, final RealmRepresentation local) {
+        return local.getRealm();
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file, final RealmRepresentation local) {
+        return local.getRealm();
+    }
+
+    @Override
+    protected Set<String> getIgnoredPaths() {
+        final Set<String> ignoredPaths = new HashSet<>(super.getIgnoredPaths());
+        ignoredPaths.addAll(COLLECTIONS_NOT_SERVED_BY_REALM_ENDPOINT);
+        return ignoredPaths;
+    }
+
+    /**
+     * Realms on the server without a local configuration are reported as a single finding. The
+     * differs of the other entity types only descend into locally configured realms, so an
+     * unrelated realm does not produce findings for each of its entities.
+     */
+    @Override
+    protected void reportExtras() {
+        keycloak.realms()
+                .findAll()
+                .stream()
+                .map(RealmRepresentation::getRealm)
+                .filter(realm -> !configuredRealms.contains(realm))
+                .forEach(realm -> reportExtra(realm, realm));
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/RealmRoleDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/RealmRoleDiffer.java
@@ -1,0 +1,55 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+@ApplicationScoped
+public class RealmRoleDiffer extends AbstractDiffer<RoleRepresentation> {
+    @Override
+    public EntityType getType() {
+        return EntityType.REALM_ROLE;
+    }
+
+    @Override
+    protected RoleRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), RoleRepresentation.class);
+    }
+
+    @Override
+    protected RoleRepresentation findServerEntity(final ConfigurationFile file,
+            final RoleRepresentation local) {
+        return keycloakCache.getRoleByName(file.getRealmName(), local.getName());
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file, final RoleRepresentation local) {
+        return local.getName();
+    }
+
+    @Override
+    protected Set<String> getIgnoredPaths() {
+        final Set<String> ignoredPaths = new HashSet<>(super.getIgnoredPaths());
+        // Composite role membership is served by a separate endpoint and is not applied by the
+        // 'configure' command either, so it is out of scope for the comparison.
+        ignoredPaths.add("composites");
+        return ignoredPaths;
+    }
+
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        return keycloak.realm(realm)
+                .roles()
+                .list()
+                .stream()
+                .map(RoleRepresentation::getName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ServiceAccountClientRoleDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ServiceAccountClientRoleDiffer.java
@@ -1,0 +1,118 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ServiceUserClientRoleMappingDTO;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.Difference;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.quarkus.logging.Log;
+
+/**
+ * Compares the client roles assigned to a service account against the local configuration.
+ * <p>
+ * The comparison is bidirectional for the declared clients: roles that are assigned on the server
+ * but not configured locally are reported as well, because the local file declares the complete
+ * set of roles for its client.
+ */
+@ApplicationScoped
+public class ServiceAccountClientRoleDiffer
+        extends AbstractDiffer<List<ServiceUserClientRoleMappingDTO>> {
+    @Override
+    public EntityType getType() {
+        return EntityType.SERVICE_ACCOUNT_CLIENT_ROLE;
+    }
+
+    @Override
+    protected List<ServiceUserClientRoleMappingDTO> loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), new TypeReference<>() { });
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file,
+            final List<ServiceUserClientRoleMappingDTO> local) {
+        return file.getServiceUsername();
+    }
+
+    /**
+     * Compares every configured mapping separately, so that the report names the client whose
+     * roles differ.
+     */
+    @Override
+    protected void diffEntity(final ConfigurationFile file) {
+        final List<ServiceUserClientRoleMappingDTO> local = loadEntity(file);
+        final String realm = getRealmName(file, local);
+        final String serviceUsername = getEntityName(file, local);
+        reporter.entityChecked();
+
+        final List<ServiceUserClientRoleMappingDTO> server = findServerEntity(file, local);
+        if (server == null) {
+            reporter.add(Difference.missingOnServer(getType(), realm, serviceUsername));
+            return;
+        }
+
+        for (int i = 0; i < local.size(); i++) {
+            final ServiceUserClientRoleMappingDTO localMapping = local.get(i);
+            final String entity = serviceUsername + " -> " + localMapping.getClient();
+            final ServiceUserClientRoleMappingDTO serverMapping = server.get(i);
+            if (serverMapping == null) {
+                reporter.add(Difference.missingOnServer(getType(), realm, entity));
+                continue;
+            }
+            compare(realm, entity, localMapping, serverMapping);
+        }
+    }
+
+    /**
+     * Reads the client roles actually assigned to the service account. The result holds one entry
+     * per locally configured mapping, in the same order, and null where the client does not exist.
+     */
+    @Override
+    protected List<ServiceUserClientRoleMappingDTO> findServerEntity(final ConfigurationFile file,
+            final List<ServiceUserClientRoleMappingDTO> local) {
+        final String realm = file.getRealmName();
+        final UserRepresentation serviceUser =
+                findUserByExactUsername(realm, file.getServiceUsername());
+        if (serviceUser == null) {
+            return null;
+        }
+
+        final List<ServiceUserClientRoleMappingDTO> assignedMappings = new ArrayList<>();
+        for (final ServiceUserClientRoleMappingDTO mapping : local) {
+            assignedMappings.add(readAssignedRoles(realm, serviceUser, mapping.getClient()));
+        }
+        return assignedMappings;
+    }
+
+    private ServiceUserClientRoleMappingDTO readAssignedRoles(final String realm,
+            final UserRepresentation serviceUser, final String clientId) {
+        final ClientRepresentation client = keycloakCache.getClientByClientId(realm, clientId);
+        if (client == null) {
+            Log.debugf("Client '%s' of realm '%s' does not exist.", clientId, realm);
+            return null;
+        }
+
+        final ServiceUserClientRoleMappingDTO assignedMapping =
+                new ServiceUserClientRoleMappingDTO();
+        assignedMapping.setClient(clientId);
+        assignedMapping.setRoles(keycloak.realm(realm)
+                .users()
+                .get(serviceUser.getId())
+                .roles()
+                .clientLevel(client.getId())
+                .listAll()
+                .stream()
+                .map(RoleRepresentation::getName)
+                .toList());
+        return assignedMapping;
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ServiceAccountRealmRoleDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/ServiceAccountRealmRoleDiffer.java
@@ -1,0 +1,60 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ServiceUserRealmRoleMappingDTO;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+/**
+ * Compares the realm roles assigned to a service account against the local configuration.
+ * <p>
+ * The comparison is bidirectional: roles that are assigned on the server but not configured
+ * locally are reported as well, because the local file declares the complete set of realm roles
+ * of the service account.
+ */
+@ApplicationScoped
+public class ServiceAccountRealmRoleDiffer extends AbstractDiffer<ServiceUserRealmRoleMappingDTO> {
+    @Override
+    public EntityType getType() {
+        return EntityType.SERVICE_ACCOUNT_REALM_ROLE;
+    }
+
+    @Override
+    protected ServiceUserRealmRoleMappingDTO loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), ServiceUserRealmRoleMappingDTO.class);
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file,
+            final ServiceUserRealmRoleMappingDTO local) {
+        return file.getServiceUsername();
+    }
+
+    @Override
+    protected ServiceUserRealmRoleMappingDTO findServerEntity(final ConfigurationFile file,
+            final ServiceUserRealmRoleMappingDTO local) {
+        final String realm = file.getRealmName();
+        final UserRepresentation serviceUser =
+                findUserByExactUsername(realm, file.getServiceUsername());
+        if (serviceUser == null) {
+            return null;
+        }
+
+        final ServiceUserRealmRoleMappingDTO assignedMapping = new ServiceUserRealmRoleMappingDTO();
+        assignedMapping.setRoles(keycloak.realm(realm)
+                .users()
+                .get(serviceUser.getId())
+                .roles()
+                .realmLevel()
+                .listAll()
+                .stream()
+                .map(RoleRepresentation::getName)
+                .filter(role -> !builtInEntityFilter.isAutoAssignedRole(realm, role))
+                .toList());
+        return assignedMapping;
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/UserDiffer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/boundary/UserDiffer.java
@@ -1,0 +1,139 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.boundary;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class UserDiffer extends AbstractDiffer<UserRepresentation> {
+    /**
+     * Above this number of users, the users of a realm are not enumerated to find users without a
+     * local configuration. A realm federating an LDAP directory can hold tens of thousands of
+     * users, none of which are meant to be configured as code.
+     */
+    private static final int MAX_ENUMERATED_USERS = 200;
+
+    @Override
+    public EntityType getType() {
+        return EntityType.USER;
+    }
+
+    @Override
+    protected UserRepresentation loadEntity(final ConfigurationFile file) {
+        return entityLoader.loadEntity(file.getFile(), UserRepresentation.class);
+    }
+
+    @Override
+    protected UserRepresentation findServerEntity(final ConfigurationFile file,
+            final UserRepresentation local) {
+        return findUserByExactUsername(file.getRealmName(), local.getUsername());
+    }
+
+    @Override
+    protected String getEntityName(final ConfigurationFile file, final UserRepresentation local) {
+        return local.getUsername();
+    }
+
+    @Override
+    protected Set<String> getIgnoredPaths() {
+        final Set<String> ignoredPaths = new HashSet<>(super.getIgnoredPaths());
+        // The server never returns credential values, so a locally configured password can not
+        // be compared. Reporting it would be a difference on every single run.
+        ignoredPaths.add("credentials");
+        // Group membership is served by a separate endpoint and is not applied by the 'configure'
+        // command either, so it is out of scope for the comparison.
+        ignoredPaths.add("groups");
+        return ignoredPaths;
+    }
+
+    /**
+     * Role mappings are served by separate endpoints and are not part of the user representation.
+     * They are added here so that locally declared roles can be compared at all.
+     */
+    @Override
+    protected UserRepresentation normalizeServerEntity(final UserRepresentation server,
+            final ConfigurationFile file, final UserRepresentation local) {
+        final String realm = file.getRealmName();
+        if (local.getRealmRoles() != null) {
+            server.setRealmRoles(getAssignedRealmRoles(realm, server.getId()));
+        }
+        if (local.getClientRoles() != null) {
+            server.setClientRoles(
+                    getAssignedClientRoles(realm, server.getId(), local.getClientRoles().keySet()));
+        }
+        return server;
+    }
+
+    private List<String> getAssignedRealmRoles(final String realm, final String userId) {
+        return keycloak.realm(realm)
+                .users()
+                .get(userId)
+                .roles()
+                .realmLevel()
+                .listAll()
+                .stream()
+                .map(RoleRepresentation::getName)
+                .filter(role -> !builtInEntityFilter.isAutoAssignedRole(realm, role))
+                .toList();
+    }
+
+    /**
+     * Reads the assigned client roles for the clients that the local configuration declares.
+     * Clients that are not declared locally are not read, as they are not being configured.
+     */
+    private Map<String, List<String>> getAssignedClientRoles(final String realm,
+            final String userId, final Set<String> declaredClientIds) {
+        final Map<String, List<String>> assignedRoles = new LinkedHashMap<>();
+        for (final String clientId : declaredClientIds) {
+            final ClientRepresentation client = keycloakCache.getClientByClientId(realm, clientId);
+            if (client == null) {
+                Log.debugf("Cannot read client roles of unknown client '%s' in realm '%s'.",
+                        clientId, realm);
+                continue;
+            }
+
+            assignedRoles.put(clientId, keycloak.realm(realm)
+                    .users()
+                    .get(userId)
+                    .roles()
+                    .clientLevel(client.getId())
+                    .listAll()
+                    .stream()
+                    .map(RoleRepresentation::getName)
+                    .toList());
+        }
+        return assignedRoles;
+    }
+
+    @Override
+    protected Set<String> getServerEntityNames(final String realm) {
+        final Integer userCount = keycloak.realm(realm).users().count();
+        if (userCount != null && userCount > MAX_ENUMERATED_USERS) {
+            Log.warnf("Realm '%s' holds %d users, which is more than the limit of %d. Users "
+                            + "without a local configuration are not reported for this realm.",
+                    realm, userCount, Integer.valueOf(MAX_ENUMERATED_USERS));
+            return Set.of();
+        }
+
+        return keycloak.realm(realm)
+                .users()
+                .list()
+                .stream()
+                .map(UserRepresentation::getUsername)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/BuiltInEntityFilter.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/BuiltInEntityFilter.java
@@ -1,0 +1,212 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.DiffCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+/**
+ * Decides whether an entity that exists on the server but is not configured locally is a
+ * Keycloak built-in or auto-generated entity.
+ * <p>
+ * Every realm ships with a set of clients, client scopes, roles and key providers that Keycloak
+ * creates itself. Reporting them as findings would bury the actual configuration drift, so they
+ * are filtered out by default. The filter can be disabled with {@code --include-built-ins} and
+ * extended with {@code --ignore-extra}.
+ */
+@ApplicationScoped
+public class BuiltInEntityFilter {
+    private static final String REALM_MASTER = "master";
+    private static final String IGNORE_SEPARATOR = ":";
+    private static final String SUFFIX_REALM_CLIENT = "-realm";
+    private static final String PREFIX_SERVICE_ACCOUNT = "service-account-";
+
+    /**
+     * Clients that Keycloak creates for every realm.
+     */
+    private static final Set<String> BUILT_IN_CLIENTS = Set.of(
+            "account",
+            "account-console",
+            "admin-cli",
+            "broker",
+            "realm-management",
+            "security-admin-console");
+
+    /**
+     * Client scopes that Keycloak creates for every realm.
+     */
+    private static final Set<String> BUILT_IN_CLIENT_SCOPES = Set.of(
+            "acr",
+            "address",
+            "basic",
+            "email",
+            "microprofile-jwt",
+            "offline_access",
+            "organization",
+            "phone",
+            "profile",
+            "role_list",
+            "roles",
+            "saml_organization",
+            "service_account",
+            "web-origins");
+
+    /**
+     * Realm roles that Keycloak creates for every realm. The composite default role is named
+     * after the realm and therefore resolved dynamically.
+     */
+    private static final Set<String> BUILT_IN_REALM_ROLES = Set.of(
+            "offline_access",
+            "uma_authorization");
+
+    /**
+     * Realm roles that only exist in the master realm.
+     */
+    private static final Set<String> BUILT_IN_MASTER_REALM_ROLES = Set.of(
+            "admin",
+            "create-realm");
+
+    /**
+     * Key providers and client registration policies that Keycloak creates for every realm.
+     */
+    private static final Set<String> BUILT_IN_COMPONENTS = Set.of(
+            "aes-generated",
+            "hmac-generated",
+            "hmac-generated-hs512",
+            "rsa-generated",
+            "rsa-enc-generated",
+            "Allowed Client Scopes",
+            "Allowed Protocol Mapper Types",
+            "Allowed Registration Web Origins",
+            "Consent Required",
+            "Full Scope Disabled",
+            "Max Clients Limit",
+            "Trusted Hosts");
+
+    /**
+     * Component provider types that Keycloak manages itself. Every realm is created with a set of
+     * key providers and client registration policies, and their names differ between Keycloak
+     * versions. Matching on the provider type therefore covers them independently of the version.
+     */
+    private static final Set<String> BUILT_IN_COMPONENT_PROVIDER_TYPES = Set.of(
+            "org.keycloak.keys.KeyProvider",
+            "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy");
+
+    @Inject
+    DiffCommandConfiguration configuration;
+
+    /**
+     * Whether an entity found on the server should not be reported as a missing local
+     * configuration.
+     *
+     * @param entityType
+     *         the type of the entity
+     * @param realm
+     *         the realm the entity belongs to
+     * @param name
+     *         the identifying name of the entity. For client roles this is expected as
+     *         {@code clientId:roleName}
+     * @return true if the entity is a built-in or explicitly ignored entity
+     */
+    public boolean isIgnored(final EntityType entityType, final String realm, final String name) {
+        if (configuration.isIncludeBuiltIns()) {
+            return false;
+        }
+        return isExplicitlyIgnored(entityType, name) || isBuiltIn(entityType, realm, name);
+    }
+
+    private boolean isExplicitlyIgnored(final EntityType entityType, final String name) {
+        final String ignoreKey = entityType.getName() + IGNORE_SEPARATOR + name;
+        return configuration.getIgnoredExtras().contains(ignoreKey);
+    }
+
+    private boolean isBuiltIn(final EntityType entityType, final String realm, final String name) {
+        return switch (entityType) {
+            case REALM -> REALM_MASTER.equals(name);
+            case CLIENT -> isBuiltInClient(realm, name);
+            case CLIENT_SCOPE -> BUILT_IN_CLIENT_SCOPES.contains(name);
+            case CLIENT_ROLE -> isRoleOfBuiltInClient(realm, name);
+            case REALM_ROLE -> isBuiltInRealmRole(realm, name);
+            case USER -> isBuiltInUser(name);
+            case COMPONENT -> BUILT_IN_COMPONENTS.contains(name);
+            case GROUP, SERVICE_ACCOUNT_CLIENT_ROLE, SERVICE_ACCOUNT_REALM_ROLE -> false;
+        };
+    }
+
+    private boolean isBuiltInClient(final String realm, final String clientId) {
+        if (BUILT_IN_CLIENTS.contains(clientId)) {
+            return true;
+        }
+        // The master realm holds a management client for every other realm, e.g. 'realm-a-realm'.
+        return REALM_MASTER.equals(realm) && clientId.endsWith(SUFFIX_REALM_CLIENT);
+    }
+
+    /**
+     * Roles of a built-in client are built-in as well, so they are ignored together with their
+     * client.
+     */
+    private boolean isRoleOfBuiltInClient(final String realm, final String name) {
+        final int separator = name.indexOf(IGNORE_SEPARATOR);
+        if (separator < 0) {
+            return false;
+        }
+        return isBuiltInClient(realm, name.substring(0, separator));
+    }
+
+    private boolean isBuiltInRealmRole(final String realm, final String name) {
+        if (BUILT_IN_REALM_ROLES.contains(name) || defaultRolesName(realm).equals(name)) {
+            return true;
+        }
+        return REALM_MASTER.equals(realm) && BUILT_IN_MASTER_REALM_ROLES.contains(name);
+    }
+
+    /**
+     * Service account users are created together with their client, and the user the tool
+     * authenticated with is never part of the configuration.
+     */
+    private boolean isBuiltInUser(final String username) {
+        return username.startsWith(PREFIX_SERVICE_ACCOUNT)
+                || username.equalsIgnoreCase(configuration.getUsername());
+    }
+
+    /**
+     * Whether a component is managed by Keycloak itself, judged by its provider type.
+     *
+     * @param providerType
+     *         the provider type of the component
+     * @return true if Keycloak creates components of this type on its own
+     */
+    public boolean isBuiltInComponentProviderType(final String providerType) {
+        return !configuration.isIncludeBuiltIns()
+                && BUILT_IN_COMPONENT_PROVIDER_TYPES.contains(providerType);
+    }
+
+    /**
+     * Whether a role is assigned by Keycloak itself. Keycloak grants the composite default role
+     * of a realm to every new user and service account, so it shows up in every role mapping
+     * read from the server without ever being configured locally.
+     *
+     * @param realm
+     *         the realm the role belongs to
+     * @param roleName
+     *         the name of the role
+     * @return true if the role assignment is created by Keycloak
+     */
+    public boolean isAutoAssignedRole(final String realm, final String roleName) {
+        return !configuration.isIncludeBuiltIns() && defaultRolesName(realm).equals(roleName);
+    }
+
+    /**
+     * The name of the composite default role Keycloak creates for a realm.
+     *
+     * @param realm
+     *         the realm name
+     * @return the name of the realm's default role
+     */
+    public static String defaultRolesName(final String realm) {
+        return "default-roles-" + realm;
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/ConfiguredRealms.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/ConfiguredRealms.java
@@ -1,0 +1,82 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.keycloak.representations.idm.RealmRepresentation;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.control.ConfigurationFileStore;
+import com.cycrilabs.keycloak.configurator.commands.configure.entity.ConfigurationFile;
+import com.cycrilabs.keycloak.configurator.shared.control.ConfigurationEntityLoader;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+
+/**
+ * The set of realms that the local configuration describes.
+ * <p>
+ * Entities that exist on the server without a local configuration file are only reported for
+ * these realms. A server usually hosts realms that are entirely unrelated to the configuration
+ * at hand, and descending into them would produce hundreds of findings that say nothing about
+ * the configuration being verified.
+ */
+@ApplicationScoped
+public class ConfiguredRealms {
+    @Inject
+    ConfigurationFileStore configurationFileStore;
+    @Inject
+    ConfigurationEntityLoader entityLoader;
+
+    private Set<String> realms;
+
+    /**
+     * The names of all realms described by the local configuration.
+     *
+     * @return the configured realm names
+     */
+    public Set<String> get() {
+        if (realms == null) {
+            realms = resolve();
+            Log.debugf("Local configuration describes realms %s.", realms);
+        }
+        return realms;
+    }
+
+    public boolean contains(final String realm) {
+        return realm != null && get().contains(realm);
+    }
+
+    private Set<String> resolve() {
+        final Set<String> configuredRealms = new LinkedHashSet<>();
+        for (final EntityType entityType : EntityType.values()) {
+            for (final ConfigurationFile file : configurationFileStore.getImportFiles(entityType)) {
+                if (file.getRealmName() != null) {
+                    configuredRealms.add(file.getRealmName());
+                }
+                if (entityType == EntityType.REALM) {
+                    // Realm files carry no realm name when read from a nested directory
+                    // structure, so the name is taken from the file content itself.
+                    addRealmNameFromFile(configuredRealms, file);
+                }
+            }
+        }
+        return configuredRealms;
+    }
+
+    private void addRealmNameFromFile(final Set<String> configuredRealms,
+            final ConfigurationFile file) {
+        try {
+            final RealmRepresentation realm =
+                    entityLoader.loadEntity(file.getFile(), RealmRepresentation.class);
+            if (realm.getRealm() != null) {
+                configuredRealms.add(realm.getRealm());
+            }
+        } catch (final RuntimeException e) {
+            Log.warnf("Could not determine realm name from file '%s': %s", file.getFile(),
+                    e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffCommand.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffCommand.java
@@ -1,0 +1,83 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import static com.cycrilabs.keycloak.configurator.shared.control.MeasuredMethodExecutor.measureExecutionTime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+
+import com.cycrilabs.keycloak.configurator.commands.configure.control.ConfigurationFileStore;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.ServerUnreachableException;
+import com.cycrilabs.keycloak.configurator.shared.control.EntityTypeConverter;
+import com.cycrilabs.keycloak.configurator.shared.control.KeycloakOptions;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+import io.quarkus.logging.Log;
+import picocli.CommandLine;
+
+/**
+ * Reports all differences between a Keycloak server and the local configuration without modifying
+ * the server.
+ */
+@CommandLine.Command(name = "diff", mixinStandardHelpOptions = true)
+public class DiffCommand implements Callable<Integer> {
+    /**
+     * Exit code returned when the server matches the local configuration.
+     */
+    private static final int EXIT_CODE_IN_SYNC = 0;
+    /**
+     * Exit code returned when differences were found, so that the command can be used as a check.
+     */
+    private static final int EXIT_CODE_DIFFERENCES_FOUND = 1;
+    /**
+     * Exit code returned when the server could not be compared at all. This is deliberately not
+     * the exit code of a found difference, so that an unreachable server is not mistaken for a
+     * configuration that was never applied.
+     */
+    private static final int EXIT_CODE_SERVER_UNREACHABLE = 3;
+
+    @CommandLine.Mixin
+    KeycloakOptions keycloakOptions;
+    @CommandLine.Option(required = true, names = { "-c", "--config" },
+            description = "Directory containing the keycloak configuration files.")
+    String configDirectory = "";
+    @CommandLine.Option(names = { "-t", "--entity-type" },
+            description = "Entity type to compare. If not provided, all entities are compared.",
+            converter = EntityTypeConverter.class)
+    EntityType entityType;
+    @CommandLine.Option(names = { "--flat-files" },
+            description = "Read configuration files from a flat file list instead of nested type directories.")
+    boolean flatFiles;
+    @CommandLine.Option(names = { "--include-built-ins" },
+            description = "Also report Keycloak built-in and auto-generated entities that are not configured locally.")
+    boolean includeBuiltIns;
+    @CommandLine.Option(names = { "--ignore-extra" }, paramLabel = "<type>:<name>",
+            description = "Entity that must not be reported when it only exists on the server, e.g. 'client:legacy-app'. Can be given multiple times.")
+    List<String> ignoreExtra = new ArrayList<>();
+
+    @Inject
+    ConfigurationFileStore configurationFileStore;
+    @Inject
+    DiffRunner diffRunner;
+
+    @Override
+    public Integer call() {
+        final AtomicInteger differences = new AtomicInteger();
+        try {
+            measureExecutionTime(() -> {
+                configurationFileStore.init();
+                differences.set(diffRunner.run());
+            }, "DiffCommand");
+        } catch (final ServerUnreachableException e) {
+            Log.error(e.getMessage());
+            return EXIT_CODE_SERVER_UNREACHABLE;
+        }
+
+        return differences.get() == 0
+               ? EXIT_CODE_IN_SYNC
+               : EXIT_CODE_DIFFERENCES_FOUND;
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffCommandConfigurationProducer.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffCommandConfigurationProducer.java
@@ -1,0 +1,17 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.DiffCommandConfiguration;
+
+import picocli.CommandLine;
+
+@ApplicationScoped
+public class DiffCommandConfigurationProducer {
+    @Produces
+    @ApplicationScoped
+    DiffCommandConfiguration createConfiguration(final CommandLine.ParseResult parseResult) {
+        return new DiffCommandConfiguration(parseResult);
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffReporter.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffReporter.java
@@ -1,0 +1,141 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.Difference;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.DifferenceKind;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.FieldDifference;
+
+import io.quarkus.logging.Log;
+
+/**
+ * Collects all detected differences and renders them as a report grouped by realm, entity type
+ * and entity.
+ */
+@ApplicationScoped
+public class DiffReporter {
+    private static final String REALM_UNKNOWN = "<unknown realm>";
+
+    private final List<Difference> differences = new ArrayList<>();
+    private int checkedEntities;
+
+    public void add(final Difference difference) {
+        differences.add(difference);
+    }
+
+    /**
+     * Records that an entity was compared against the server. Used for the report summary only.
+     */
+    public void entityChecked() {
+        checkedEntities++;
+    }
+
+    /**
+     * The number of detected differences. A value of zero means the server matches the local
+     * configuration.
+     *
+     * @return the number of differences
+     */
+    public int getDifferenceCount() {
+        return differences.size();
+    }
+
+    /**
+     * Writes the report of all collected differences.
+     */
+    public void render() {
+        if (differences.isEmpty()) {
+            Log.infof("No differences found. %d entities are in sync with the local configuration.",
+                    Integer.valueOf(checkedEntities));
+            return;
+        }
+
+        final Map<String, List<Difference>> differencesByRealm = differences.stream()
+                .collect(Collectors.groupingBy(DiffReporter::realmOf, TreeMap::new,
+                        Collectors.toList()));
+        differencesByRealm.forEach(DiffReporter::renderRealm);
+
+        renderSummary(differencesByRealm.size());
+    }
+
+    private static void renderRealm(final String realm, final List<Difference> realmDifferences) {
+        Log.infof("=== %s ===", realm);
+
+        renderEntityDifferences(realmDifferences.stream()
+                .filter(difference -> difference.kind() != DifferenceKind.EXTRA_ON_SERVER)
+                .toList());
+
+        realmDifferences.stream()
+                .filter(difference -> difference.kind() == DifferenceKind.EXTRA_ON_SERVER)
+                .sorted(entityOrder())
+                .forEach(difference -> Log.infof("  EXTRA on server: %s '%s'",
+                        difference.entityType().getName(), difference.entity()));
+    }
+
+    private static void renderEntityDifferences(final List<Difference> entityDifferences) {
+        // Preserve a stable order: entity types as they are imported, entities alphabetically.
+        final Map<String, List<Difference>> groupedByEntity = entityDifferences.stream()
+                .sorted(entityOrder())
+                .collect(Collectors.groupingBy(
+                        difference -> difference.entityType().getName() + " '"
+                                + difference.entity() + "'",
+                        LinkedHashMap::new, Collectors.toList()));
+
+        groupedByEntity.forEach((entity, differencesOfEntity) -> {
+            Log.infof("  %s", entity);
+            differencesOfEntity.forEach(DiffReporter::renderDifference);
+        });
+    }
+
+    private static void renderDifference(final Difference difference) {
+        if (difference.kind() == DifferenceKind.MISSING_ON_SERVER) {
+            Log.info("    MISSING on server");
+            return;
+        }
+
+        final FieldDifference field = difference.field();
+        switch (field.kind()) {
+            case MISSING_ON_SERVER -> Log.infof("    ~ %s: not set on server (local=%s)",
+                    field.path(), field.localValue());
+            case VALUE_DIFFERENT -> Log.infof("    ~ %s: local=%s server=%s", field.path(),
+                    field.localValue(), field.serverValue());
+            case ONLY_IN_LOCAL -> Log.infof("    ~ %s: only in local: %s", field.path(),
+                    field.localValue());
+            case ONLY_ON_SERVER -> Log.infof("    ~ %s: only on server: %s", field.path(),
+                    field.serverValue());
+        }
+    }
+
+    private void renderSummary(final int affectedRealms) {
+        final Set<String> affectedEntities = differences.stream()
+                .map(difference -> realmOf(difference) + "/" + difference.entityType().getName()
+                        + "/" + difference.entity())
+                .collect(Collectors.toSet());
+
+        Log.infof("%d differences across %d entities in %d realm(s). %d entities checked.",
+                Integer.valueOf(differences.size()), Integer.valueOf(affectedEntities.size()),
+                Integer.valueOf(affectedRealms), Integer.valueOf(checkedEntities));
+    }
+
+    private static Comparator<Difference> entityOrder() {
+        return Comparator.<Difference>comparingInt(
+                        difference -> difference.entityType().getPriority())
+                .thenComparing(Difference::entity,
+                        Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
+    private static String realmOf(final Difference difference) {
+        return difference.realm() == null
+               ? REALM_UNKNOWN
+               : difference.realm();
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffRunner.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffRunner.java
@@ -1,0 +1,83 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import java.util.Comparator;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.keycloak.admin.client.Keycloak;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.boundary.AbstractDiffer;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.DiffCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.ServerUnreachableException;
+
+import io.quarkus.logging.Log;
+
+/**
+ * Runs all differs and renders the resulting report.
+ */
+@ApplicationScoped
+public class DiffRunner {
+    private final DiffCommandConfiguration configuration;
+    private final Instance<AbstractDiffer<?>> differs;
+    private final DiffReporter reporter;
+    private final Keycloak keycloak;
+
+    @Inject
+    public DiffRunner(
+            final DiffCommandConfiguration configuration,
+            final Instance<AbstractDiffer<?>> differs,
+            final DiffReporter reporter,
+            final Keycloak keycloak
+    ) {
+        this.configuration = configuration;
+        this.differs = differs;
+        this.reporter = reporter;
+        this.keycloak = keycloak;
+    }
+
+    /**
+     * Compares the server against the local configuration. The server is only read, never
+     * modified.
+     *
+     * @return the number of detected differences
+     * @throws ServerUnreachableException
+     *         if the server cannot be reached or the credentials are rejected
+     */
+    public int run() {
+        Log.infof("Comparing server %s against configuration %s. The server is not modified.",
+                configuration.getServer(), configuration.getConfigDirectory());
+
+        verifyServerIsReachable();
+
+        // Differs run in the order the entities are imported, so that findings are reported from
+        // the realm down to its details.
+        final List<AbstractDiffer<?>> sortedDiffers = differs.stream()
+                .sorted(Comparator.comparingInt(AbstractDiffer::getPriority))
+                .toList();
+        for (final AbstractDiffer<?> differ : sortedDiffers) {
+            differ.runDiff();
+        }
+
+        reporter.render();
+        return reporter.getDifferenceCount();
+    }
+
+    /**
+     * Fails before anything is compared if the server cannot be reached or the credentials are
+     * rejected. Without this check every entity would look as if it did not exist on the server,
+     * which is indistinguishable from a configuration that was never applied.
+     */
+    private void verifyServerIsReachable() {
+        try {
+            keycloak.tokenManager().getAccessToken();
+        } catch (final RuntimeException e) {
+            throw new ServerUnreachableException(
+                    "Could not authenticate against server '%s' as user '%s': %s".formatted(
+                            configuration.getServer(), configuration.getUsername(),
+                            e.getMessage()), e);
+        }
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/JsonDiffEngine.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/control/JsonDiffEngine.java
@@ -1,0 +1,398 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import lombok.NoArgsConstructor;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.FieldDifference;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.FieldDifferenceKind;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Compares a locally configured entity against its server counterpart.
+ * <p>
+ * The comparison is driven by the <em>local</em> side: only fields that the local configuration
+ * actually declares are compared. Fields that only the server knows about - such as generated
+ * identifiers, secrets or Keycloak defaults - are not differences, because a configuration file
+ * is intentionally a partial description of an entity.
+ * <p>
+ * Within a declared collection the comparison is bidirectional: since the field itself was
+ * declared, elements that only exist on the server are reported as well. Collections of scalars
+ * are compared as sets, because Keycloak does not treat their order as significant.
+ */
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class JsonDiffEngine {
+    /**
+     * Field names whose values must never be written to the report.
+     */
+    private static final Set<String> REDACTED_FIELD_NAMES =
+            Set.of("secret", "bindCredential", "password", "privateKey");
+    private static final String REDACTED_PLACEHOLDER = "<redacted>";
+    private static final String MATCH_FIELD_NAME = "name";
+    private static final String FIELD_CREDENTIALS = "credentials";
+    private static final String FIELD_VALUE = "value";
+
+    /**
+     * Compares the local entity against the server entity and reports every difference of a
+     * locally declared field to the given sink.
+     *
+     * @param local
+     *         the entity as declared in the local configuration
+     * @param server
+     *         the entity as returned by the server
+     * @param ignoredPaths
+     *         field paths that must not be compared because they are not comparable, e.g.
+     *         because the local configuration references a parent by name while the server
+     *         reports a generated identifier
+     * @param sink
+     *         receives every detected difference
+     */
+    public static void compare(final JsonNode local, final JsonNode server,
+            final Set<String> ignoredPaths, final Consumer<FieldDifference> sink) {
+        compareNode("", local, server, ignoredPaths, sink);
+    }
+
+    private static void compareNode(final String path, final JsonNode local, final JsonNode server,
+            final Set<String> ignoredPaths, final Consumer<FieldDifference> sink) {
+        if (local.isObject()) {
+            compareObject(path, local, server, ignoredPaths, sink);
+        } else if (local.isArray()) {
+            compareArray(path, local, server, ignoredPaths, sink);
+        } else {
+            compareValue(path, local, server, sink);
+        }
+    }
+
+    private static void compareObject(final String path, final JsonNode local,
+            final JsonNode server, final Set<String> ignoredPaths,
+            final Consumer<FieldDifference> sink) {
+        if (!server.isObject()) {
+            sink.accept(valueDifference(path, local, server));
+            return;
+        }
+
+        for (final Map.Entry<String, JsonNode> field : local.properties()) {
+            final String childPath = childPath(path, field.getKey());
+            final JsonNode localChild = field.getValue();
+
+            // A field that is absent or null locally declares nothing, so there is nothing to
+            // compare. Configuration files exported from a server contain many null fields.
+            if (isUndeclared(localChild) || isIgnored(childPath, ignoredPaths)) {
+                continue;
+            }
+
+            final JsonNode serverChild = server.get(field.getKey());
+            if (serverChild == null || serverChild.isNull()) {
+                // An empty collection or object declares nothing, so it does not differ from a
+                // field the server does not report at all.
+                if (!isEmptyContainer(localChild)) {
+                    sink.accept(new FieldDifference(childPath,
+                            FieldDifferenceKind.MISSING_ON_SERVER, render(childPath, localChild),
+                            null));
+                }
+                continue;
+            }
+
+            compareNode(childPath, localChild, serverChild, ignoredPaths, sink);
+        }
+    }
+
+    private static void compareArray(final String path, final JsonNode local, final JsonNode server,
+            final Set<String> ignoredPaths, final Consumer<FieldDifference> sink) {
+        if (!server.isArray()) {
+            sink.accept(valueDifference(path, local, server));
+            return;
+        }
+
+        if (containsOnlyValues(local) && containsOnlyValues(server)) {
+            compareValueArray(path, local, server, sink);
+        } else if (isMatchableByName(local) && isMatchableByName(server)) {
+            compareArrayByName(path, local, server, ignoredPaths, sink);
+        } else {
+            compareArrayByIndex(path, local, server, ignoredPaths, sink);
+        }
+    }
+
+    /**
+     * Compares collections of scalars as sets, as their order is not significant.
+     */
+    private static void compareValueArray(final String path, final JsonNode local,
+            final JsonNode server, final Consumer<FieldDifference> sink) {
+        final Set<String> localValues = toValueSet(local);
+        final Set<String> serverValues = toValueSet(server);
+
+        reportMissingElements(path, localValues, serverValues, FieldDifferenceKind.ONLY_IN_LOCAL,
+                sink);
+        reportMissingElements(path, serverValues, localValues, FieldDifferenceKind.ONLY_ON_SERVER,
+                sink);
+    }
+
+    private static void reportMissingElements(final String path, final Set<String> from,
+            final Set<String> other, final FieldDifferenceKind kind,
+            final Consumer<FieldDifference> sink) {
+        final List<String> missing = from.stream()
+                .filter(value -> !other.contains(value))
+                .toList();
+        if (missing.isEmpty()) {
+            return;
+        }
+
+        final String rendered = renderElements(path, missing);
+        sink.accept(kind == FieldDifferenceKind.ONLY_IN_LOCAL
+                    ? new FieldDifference(path, kind, rendered, null)
+                    : new FieldDifference(path, kind, null, rendered));
+    }
+
+    /**
+     * Compares collections of objects by their 'name' field, as their order is not significant.
+     */
+    private static void compareArrayByName(final String path, final JsonNode local,
+            final JsonNode server, final Set<String> ignoredPaths,
+            final Consumer<FieldDifference> sink) {
+        final List<String> onlyInLocal = new ArrayList<>();
+        for (final JsonNode localElement : local) {
+            final String name = localElement.get(MATCH_FIELD_NAME).asText();
+            final JsonNode serverElement = findByName(server, name);
+            if (serverElement == null) {
+                onlyInLocal.add(name);
+            } else {
+                compareNode(elementPath(path, name), localElement, serverElement, ignoredPaths,
+                        sink);
+            }
+        }
+        if (!onlyInLocal.isEmpty()) {
+            sink.accept(new FieldDifference(path, FieldDifferenceKind.ONLY_IN_LOCAL,
+                    renderElements(path, onlyInLocal), null));
+        }
+
+        final List<String> onlyOnServer = new ArrayList<>();
+        for (final JsonNode serverElement : server) {
+            final String name = serverElement.get(MATCH_FIELD_NAME).asText();
+            if (findByName(local, name) == null) {
+                onlyOnServer.add(name);
+            }
+        }
+        if (!onlyOnServer.isEmpty()) {
+            sink.accept(new FieldDifference(path, FieldDifferenceKind.ONLY_ON_SERVER, null,
+                    renderElements(path, onlyOnServer)));
+        }
+    }
+
+    /**
+     * Fallback for collections whose elements cannot be identified by name.
+     */
+    private static void compareArrayByIndex(final String path, final JsonNode local,
+            final JsonNode server, final Set<String> ignoredPaths,
+            final Consumer<FieldDifference> sink) {
+        for (int i = 0; i < local.size(); i++) {
+            if (i >= server.size()) {
+                sink.accept(new FieldDifference(path, FieldDifferenceKind.ONLY_IN_LOCAL,
+                        render(path, local.get(i)), null));
+            } else {
+                compareNode(elementPath(path, String.valueOf(i)), local.get(i), server.get(i),
+                        ignoredPaths, sink);
+            }
+        }
+        for (int i = local.size(); i < server.size(); i++) {
+            sink.accept(new FieldDifference(path, FieldDifferenceKind.ONLY_ON_SERVER, null,
+                    render(path, server.get(i))));
+        }
+    }
+
+    private static void compareValue(final String path, final JsonNode local, final JsonNode server,
+            final Consumer<FieldDifference> sink) {
+        if (!isEqualValue(local, server)) {
+            sink.accept(valueDifference(path, local, server));
+        }
+    }
+
+    /**
+     * Compares two scalars leniently: numbers are compared by their numeric value so that an
+     * integer and a long holding the same number are equal, everything else is compared by its
+     * textual representation.
+     */
+    private static boolean isEqualValue(final JsonNode local, final JsonNode server) {
+        if (local.isNumber() && server.isNumber()) {
+            return local.decimalValue().compareTo(server.decimalValue()) == 0;
+        }
+        if (local.isContainerNode() || server.isContainerNode()) {
+            return local.equals(server);
+        }
+        return local.asText().equals(server.asText());
+    }
+
+    private static FieldDifference valueDifference(final String path, final JsonNode local,
+            final JsonNode server) {
+        return new FieldDifference(path, FieldDifferenceKind.VALUE_DIFFERENT,
+                render(path, local), render(path, server));
+    }
+
+    private static JsonNode findByName(final JsonNode array, final String name) {
+        for (final JsonNode element : array) {
+            if (name.equals(element.get(MATCH_FIELD_NAME).asText())) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isUndeclared(final JsonNode node) {
+        return node == null || node.isNull();
+    }
+
+    private static boolean isEmptyContainer(final JsonNode node) {
+        return node.isContainerNode() && node.isEmpty();
+    }
+
+    /**
+     * Whether a field must not be compared. An entry of the ignore set matches either the full
+     * path of the field or its name at any depth, so that e.g. 'id' suppresses all generated
+     * identifiers while 'config.bindCredential' only suppresses that single field.
+     *
+     * @param path
+     *         the full path of the field
+     * @param ignoredPaths
+     *         the configured ignore set
+     * @return true if the field must not be compared
+     */
+    private static boolean isIgnored(final String path, final Set<String> ignoredPaths) {
+        return ignoredPaths.contains(path) || ignoredPaths.contains(leafName(path));
+    }
+
+    private static boolean containsOnlyValues(final JsonNode array) {
+        for (final JsonNode element : array) {
+            if (element.isContainerNode()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isMatchableByName(final JsonNode array) {
+        if (array.isEmpty()) {
+            return false;
+        }
+        for (final JsonNode element : array) {
+            if (!element.isObject() || !element.hasNonNull(MATCH_FIELD_NAME)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Set<String> toValueSet(final JsonNode array) {
+        final Set<String> values = new LinkedHashSet<>();
+        for (final JsonNode element : array) {
+            values.add(element.asText());
+        }
+        return values;
+    }
+
+    private static String childPath(final String path, final String field) {
+        return path.isEmpty()
+               ? field
+               : path + "." + field;
+    }
+
+    private static String elementPath(final String path, final String element) {
+        return path + "[" + element + "]";
+    }
+
+    private static String renderElements(final String path, final List<String> elements) {
+        if (isRedacted(path)) {
+            return REDACTED_PLACEHOLDER;
+        }
+        return "[" + String.join(", ", elements) + "]";
+    }
+
+    private static String render(final String path, final JsonNode node) {
+        if (isRedacted(path)) {
+            return REDACTED_PLACEHOLDER;
+        }
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isTextual()) {
+            return "\"" + node.asText() + "\"";
+        }
+        if (node.isContainerNode()) {
+            // A whole object or collection is rendered when it has no counterpart at all. It may
+            // carry sensitive values further down, e.g. the credentials of a user. The rendered
+            // node can be an element of a collection, so the context is taken from the path.
+            return maskSensitiveValues(node, path.contains(FIELD_CREDENTIALS)).toString();
+        }
+        return node.toString();
+    }
+
+    /**
+     * Creates a copy of the given node in which all sensitive values are replaced by a
+     * placeholder.
+     *
+     * @param node
+     *         the node to mask
+     * @param withinCredentials
+     *         whether the node is part of a credentials collection, whose values are sensitive
+     *         regardless of their field name
+     * @return the masked copy of the node
+     */
+    private static JsonNode maskSensitiveValues(final JsonNode node,
+            final boolean withinCredentials) {
+        if (node.isObject()) {
+            final ObjectNode masked = ((ObjectNode) node).objectNode();
+            for (final Map.Entry<String, JsonNode> field : node.properties()) {
+                final String name = field.getKey();
+                if (REDACTED_FIELD_NAMES.contains(name)
+                        || (withinCredentials && FIELD_VALUE.equals(name))) {
+                    masked.put(name, REDACTED_PLACEHOLDER);
+                } else {
+                    masked.set(name, maskSensitiveValues(field.getValue(),
+                            withinCredentials || FIELD_CREDENTIALS.equals(name)));
+                }
+            }
+            return masked;
+        }
+
+        if (node.isArray()) {
+            final ArrayNode masked = ((ArrayNode) node).arrayNode();
+            for (final JsonNode element : node) {
+                masked.add(maskSensitiveValues(element, withinCredentials));
+            }
+            return masked;
+        }
+
+        return node;
+    }
+
+    /**
+     * Whether the value of the given path is sensitive. The report is written to the console and
+     * ends up in build logs, so such values are replaced by a placeholder. The difference itself
+     * is still reported.
+     *
+     * @param path
+     *         the field path to check
+     * @return true if the value must not be rendered
+     */
+    private static boolean isRedacted(final String path) {
+        final String leaf = leafName(path);
+        return REDACTED_FIELD_NAMES.contains(leaf)
+                || ("value".equals(leaf) && path.contains("credentials"));
+    }
+
+    private static String leafName(final String path) {
+        final int lastSeparator = path.lastIndexOf('.');
+        final String leaf = lastSeparator < 0
+                            ? path
+                            : path.substring(lastSeparator + 1);
+        final int elementStart = leaf.indexOf('[');
+        return elementStart < 0
+               ? leaf
+               : leaf.substring(0, elementStart);
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/DiffCommandConfiguration.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/DiffCommandConfiguration.java
@@ -1,0 +1,38 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.entity;
+
+import java.util.List;
+
+import lombok.Getter;
+
+import com.cycrilabs.keycloak.configurator.shared.entity.ConfigurationSource;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+import com.cycrilabs.keycloak.configurator.shared.entity.KeycloakConfiguration;
+
+import picocli.CommandLine.ParseResult;
+
+@Getter
+public class DiffCommandConfiguration extends KeycloakConfiguration
+        implements ConfigurationSource {
+    private String configDirectory;
+    private EntityType entityType;
+    private boolean flatFiles;
+    private boolean includeBuiltIns;
+    private List<String> ignoredExtras = List.of();
+
+    public DiffCommandConfiguration() {
+        // required to avoid "No default constructor for class" error
+    }
+
+    public DiffCommandConfiguration(final ParseResult parseResult) {
+        super(parseResult);
+        configDirectory = getMatchedOption(parseResult, "-c");
+        entityType = getMatchedOption(parseResult, "-t");
+        flatFiles = this.<Boolean>getMatchedOption(parseResult, "--flat-files").booleanValue();
+        includeBuiltIns =
+                this.<Boolean>getMatchedOption(parseResult, "--include-built-ins").booleanValue();
+        final List<String> configuredIgnores = getMatchedOption(parseResult, "--ignore-extra");
+        ignoredExtras = configuredIgnores == null
+                        ? List.of()
+                        : List.copyOf(configuredIgnores);
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/Difference.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/Difference.java
@@ -1,0 +1,40 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.entity;
+
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+/**
+ * A single reported difference between the server and the local configuration.
+ *
+ * @param entityType
+ *         the type of the affected entity
+ * @param realm
+ *         the realm the entity belongs to
+ * @param entity
+ *         the identifying name of the entity, e.g. {@code blog} or {@code blog:posts-create}
+ * @param kind
+ *         the kind of difference
+ * @param field
+ *         the affected field, only set for {@link DifferenceKind#FIELD_DIFFERENT}
+ */
+public record Difference(
+        EntityType entityType,
+        String realm,
+        String entity,
+        DifferenceKind kind,
+        FieldDifference field
+) {
+    public static Difference missingOnServer(final EntityType entityType, final String realm,
+            final String entity) {
+        return new Difference(entityType, realm, entity, DifferenceKind.MISSING_ON_SERVER, null);
+    }
+
+    public static Difference extraOnServer(final EntityType entityType, final String realm,
+            final String entity) {
+        return new Difference(entityType, realm, entity, DifferenceKind.EXTRA_ON_SERVER, null);
+    }
+
+    public static Difference fieldDifferent(final EntityType entityType, final String realm,
+            final String entity, final FieldDifference field) {
+        return new Difference(entityType, realm, entity, DifferenceKind.FIELD_DIFFERENT, field);
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/DifferenceKind.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/DifferenceKind.java
@@ -1,0 +1,19 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.entity;
+
+/**
+ * The kind of difference detected for an entity.
+ */
+public enum DifferenceKind {
+    /**
+     * The entity is configured locally but does not exist on the server.
+     */
+    MISSING_ON_SERVER,
+    /**
+     * The entity exists on both sides, but at least one locally declared field differs.
+     */
+    FIELD_DIFFERENT,
+    /**
+     * The entity exists on the server but is not configured locally.
+     */
+    EXTRA_ON_SERVER
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/FieldDifference.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/FieldDifference.java
@@ -1,0 +1,21 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.entity;
+
+/**
+ * A difference detected for a single field of an entity.
+ *
+ * @param path
+ *         the path of the field within the entity, e.g. {@code config.bindCredential}
+ * @param kind
+ *         the kind of difference
+ * @param localValue
+ *         the rendered local value, or the elements only present locally
+ * @param serverValue
+ *         the rendered server value, or the elements only present on the server
+ */
+public record FieldDifference(
+        String path,
+        FieldDifferenceKind kind,
+        String localValue,
+        String serverValue
+) {
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/FieldDifferenceKind.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/FieldDifferenceKind.java
@@ -1,0 +1,23 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.entity;
+
+/**
+ * The kind of difference detected for a single field of an entity.
+ */
+public enum FieldDifferenceKind {
+    /**
+     * The field is declared in the local configuration but not set on the server.
+     */
+    MISSING_ON_SERVER,
+    /**
+     * The field is set on both sides, but the values differ.
+     */
+    VALUE_DIFFERENT,
+    /**
+     * Elements of a declared collection that are only present in the local configuration.
+     */
+    ONLY_IN_LOCAL,
+    /**
+     * Elements of a declared collection that are only present on the server.
+     */
+    ONLY_ON_SERVER
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/ServerUnreachableException.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/commands/diff/entity/ServerUnreachableException.java
@@ -1,0 +1,12 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.entity;
+
+/**
+ * Thrown when the Keycloak server cannot be reached or rejects the given credentials. This is
+ * reported separately from a configuration difference, because an unreachable server would
+ * otherwise make every configured entity look as if it did not exist.
+ */
+public class ServerUnreachableException extends RuntimeException {
+    public ServerUnreachableException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/ConfigurationEntityLoader.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/ConfigurationEntityLoader.java
@@ -1,0 +1,83 @@
+package com.cycrilabs.keycloak.configurator.shared.control;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.runtime.parser.ParseException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+/**
+ * Loads entities from local configuration files. Configuration files are Velocity templates,
+ * so the supported variables are expanded before the content is deserialized.
+ * <p>
+ * This is shared by all commands reading the configuration-as-code files, so that a comparison
+ * against the server operates on exactly the same content that an import would apply.
+ */
+@ApplicationScoped
+public class ConfigurationEntityLoader {
+    private static final String VARIABLE_ENVIRONMENT = "env";
+
+    @Inject
+    EnvironmentVariableProvider environmentVariableProvider;
+
+    private Map<String, String> environmentVariables;
+
+    @PostConstruct
+    public void init() {
+        environmentVariables = environmentVariableProvider.load();
+    }
+
+    /**
+     * Loads the entity of the given file and converts it to an object of the given class.
+     *
+     * @param filepath
+     *         path to the configuration file
+     * @param dtoClass
+     *         class of the object to convert to
+     * @param <T>
+     *         type of the object to convert to
+     * @return object of the given class
+     */
+    public <T> T loadEntity(final Path filepath, final Class<T> dtoClass) {
+        return JsonUtil.fromJson(loadContent(filepath), dtoClass);
+    }
+
+    /**
+     * Loads the entity of the given file and converts it to an object of the given type.
+     *
+     * @param filepath
+     *         path to the configuration file
+     * @param dtoType
+     *         type of the object to convert to
+     * @param <T>
+     *         type of the object to convert to
+     * @return object of the given type
+     */
+    public <T> T loadEntity(final Path filepath, final TypeReference<T> dtoType) {
+        return JsonUtil.fromJson(loadContent(filepath), dtoType);
+    }
+
+    /**
+     * Loads the content of the given file and expands all supported variables.
+     *
+     * @param filepath
+     *         path to the configuration file
+     * @return the expanded file content
+     */
+    public String loadContent(final Path filepath) {
+        try {
+            final Template template = VelocityUtils.loadTemplate(filepath.toFile());
+            return VelocityUtils.mergeTemplate(template,
+                    Map.ofEntries(Map.entry(VARIABLE_ENVIRONMENT, environmentVariables)));
+        } catch (final IOException | ParseException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/EntryCommand.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/EntryCommand.java
@@ -1,6 +1,7 @@
 package com.cycrilabs.keycloak.configurator.shared.control;
 
 import com.cycrilabs.keycloak.configurator.commands.configure.control.ConfigureCommand;
+import com.cycrilabs.keycloak.configurator.commands.diff.control.DiffCommand;
 import com.cycrilabs.keycloak.configurator.commands.export.control.ExportEntitiesCommand;
 import com.cycrilabs.keycloak.configurator.commands.generate.control.GenerateSecretsCommand;
 import com.cycrilabs.keycloak.configurator.commands.secrets.control.ExportSecretsCommand;
@@ -10,7 +11,7 @@ import picocli.CommandLine;
 
 @TopCommand
 @CommandLine.Command(mixinStandardHelpOptions = true, versionProvider = VersionProvider.class,
-        subcommands = { ConfigureCommand.class, ExportEntitiesCommand.class,
+        subcommands = { ConfigureCommand.class, DiffCommand.class, ExportEntitiesCommand.class,
                 ExportSecretsCommand.class, GenerateSecretsCommand.class })
 public class EntryCommand {
 }

--- a/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/JsonUtil.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/JsonUtil.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -109,6 +110,32 @@ public class JsonUtil {
     public static <T> T loadEntity(final Path filepath, final TypeReference<T> dtoType) {
         final String json = loadJsonFromPath(filepath);
         return fromJson(json, dtoType);
+    }
+
+    /**
+     * Converts the given object to a JSON tree without an intermediate string representation.
+     *
+     * @param entity
+     *         object to convert
+     * @return the JSON tree of the object
+     */
+    public static JsonNode toJsonNode(final Object entity) {
+        return OBJECT_MAPPER.valueToTree(entity);
+    }
+
+    /**
+     * Parses the given JSON string into a JSON tree.
+     *
+     * @param content
+     *         JSON string
+     * @return the parsed JSON tree
+     */
+    public static JsonNode readTree(final String content) {
+        try {
+            return OBJECT_MAPPER.readTree(content);
+        } catch (final JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     /**

--- a/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/ReflectionConfiguration.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/shared/control/ReflectionConfiguration.java
@@ -1,5 +1,6 @@
 package com.cycrilabs.keycloak.configurator.shared.control;
 
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
 import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.representations.idm.ErrorRepresentation;
 
@@ -14,7 +15,11 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
  * of: Cannot create instance of a class: class
  * org.keycloak.representations.idm.ClientProfilesRepresentation, No default constructor found.
  * </code>
+ * <p>
+ * The same applies when a representation read from the server is serialized again, which the
+ * 'diff' command does to compare it against the local configuration.
  */
-@RegisterForReflection(targets = { ClientProfilesRepresentation.class, ErrorRepresentation.class })
+@RegisterForReflection(targets = { ClientPoliciesRepresentation.class,
+        ClientProfilesRepresentation.class, ErrorRepresentation.class })
 public class ReflectionConfiguration {
 }

--- a/src/main/java/com/cycrilabs/keycloak/configurator/shared/entity/ConfigurationSource.java
+++ b/src/main/java/com/cycrilabs/keycloak/configurator/shared/entity/ConfigurationSource.java
@@ -1,0 +1,23 @@
+package com.cycrilabs.keycloak.configurator.shared.entity;
+
+/**
+ * Describes where local configuration files are read from and in which layout they are
+ * organized. Implemented by all command configurations that read the configuration-as-code
+ * files, so that the loading infrastructure does not depend on a concrete command.
+ */
+public interface ConfigurationSource {
+    /**
+     * The directory containing the configuration files.
+     *
+     * @return path to the configuration directory
+     */
+    String getConfigDirectory();
+
+    /**
+     * Whether the configuration files are organized as a flat file list instead of nested
+     * entity type directories.
+     *
+     * @return true if a flat file layout is used
+     */
+    boolean isFlatFiles();
+}

--- a/src/test/java/com/cycrilabs/keycloak/configurator/commands/diff/control/BuiltInEntityFilterTest.java
+++ b/src/test/java/com/cycrilabs/keycloak/configurator/commands/diff/control/BuiltInEntityFilterTest.java
@@ -1,0 +1,155 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.DiffCommandConfiguration;
+import com.cycrilabs.keycloak.configurator.shared.control.JsonUtil;
+import com.cycrilabs.keycloak.configurator.shared.entity.EntityType;
+
+class BuiltInEntityFilterTest {
+    private BuiltInEntityFilter sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new BuiltInEntityFilter();
+        sut.configuration = configuration(false, "[]");
+    }
+
+    @Nested
+    class BuiltInTests {
+        @Test
+        void shouldIgnoreBuiltInClients() {
+            Assertions.assertTrue(sut.isIgnored(EntityType.CLIENT, "realm-a", "account"));
+            Assertions.assertTrue(sut.isIgnored(EntityType.CLIENT, "realm-a", "admin-cli"));
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.CLIENT, "realm-a", "security-admin-console"));
+            Assertions.assertFalse(sut.isIgnored(EntityType.CLIENT, "realm-a", "blog"));
+        }
+
+        @Test
+        void shouldIgnoreRealmManagementClients_MasterRealmOnly() {
+            // The master realm holds a management client for every other realm.
+            Assertions.assertTrue(sut.isIgnored(EntityType.CLIENT, "master", "realm-a-realm"));
+            Assertions.assertFalse(sut.isIgnored(EntityType.CLIENT, "realm-a", "realm-a-realm"));
+        }
+
+        @Test
+        void shouldIgnoreDefaultRoleOfRealm() {
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.REALM_ROLE, "realm-a", "default-roles-realm-a"));
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.REALM_ROLE, "realm-a", "offline_access"));
+            // The default role of a different realm is not a built-in of this realm.
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.REALM_ROLE, "realm-a", "default-roles-realm-b"));
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.REALM_ROLE, "realm-a", "blog-administration"));
+        }
+
+        @Test
+        void shouldIgnoreAdminRoles_MasterRealmOnly() {
+            Assertions.assertTrue(sut.isIgnored(EntityType.REALM_ROLE, "master", "create-realm"));
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.REALM_ROLE, "realm-a", "create-realm"));
+        }
+
+        @Test
+        void shouldIgnoreRolesOfBuiltInClients() {
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.CLIENT_ROLE, "realm-a", "account:manage-account"));
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.CLIENT_ROLE, "realm-a", "blog:posts-create"));
+        }
+
+        @Test
+        void shouldIgnoreServiceAccountsAndTheAdminUser() {
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.USER, "realm-a", "service-account-blog"));
+            // The user the tool authenticated with is never part of the configuration.
+            Assertions.assertTrue(sut.isIgnored(EntityType.USER, "realm-a", "keycloak"));
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.USER, "realm-a", "alice@maildrop.cc"));
+        }
+
+        @Test
+        void shouldIgnoreGeneratedKeyProvidersAndPolicies() {
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.COMPONENT, "realm-a", "rsa-generated"));
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.COMPONENT, "realm-a", "Trusted Hosts"));
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.COMPONENT, "realm-a", "ldap-provider"));
+        }
+
+        @Test
+        void shouldIgnoreBuiltInClientScopesAndMasterRealm() {
+            Assertions.assertTrue(sut.isIgnored(EntityType.CLIENT_SCOPE, "realm-a", "profile"));
+            Assertions.assertFalse(
+                    sut.isIgnored(EntityType.CLIENT_SCOPE, "realm-a", "user-info-scope"));
+            Assertions.assertTrue(sut.isIgnored(EntityType.REALM, "master", "master"));
+            Assertions.assertFalse(sut.isIgnored(EntityType.REALM, "realm-a", "realm-a"));
+        }
+
+        @Test
+        void shouldNotIgnoreGroups() {
+            Assertions.assertFalse(sut.isIgnored(EntityType.GROUP, "realm-a", "/cycrilabs"));
+        }
+    }
+
+    @Nested
+    class AutoAssignedRoleTests {
+        @Test
+        void shouldTreatDefaultRoleOfRealmAsAutoAssigned() {
+            Assertions.assertTrue(sut.isAutoAssignedRole("realm-a", "default-roles-realm-a"));
+            Assertions.assertFalse(sut.isAutoAssignedRole("realm-a", "blog-administration"));
+        }
+
+        @Test
+        void shouldNotTreatAnyRoleAsAutoAssigned_BuiltInsIncluded() {
+            sut.configuration = configuration(true, "[]");
+
+            Assertions.assertFalse(sut.isAutoAssignedRole("realm-a", "default-roles-realm-a"));
+        }
+    }
+
+    @Nested
+    class ConfigurationTests {
+        @Test
+        void shouldReportEverything_BuiltInsIncluded() {
+            sut.configuration = configuration(true, "[]");
+
+            Assertions.assertFalse(sut.isIgnored(EntityType.CLIENT, "realm-a", "account"));
+            Assertions.assertFalse(sut.isIgnored(EntityType.REALM, "master", "master"));
+        }
+
+        @Test
+        void shouldIgnoreExplicitlyConfiguredEntities() {
+            sut.configuration =
+                    configuration(false, "[ \"client:legacy-app\", \"realm-role:temp-admin\" ]");
+
+            Assertions.assertTrue(sut.isIgnored(EntityType.CLIENT, "realm-a", "legacy-app"));
+            Assertions.assertTrue(
+                    sut.isIgnored(EntityType.REALM_ROLE, "realm-a", "temp-admin"));
+            Assertions.assertFalse(sut.isIgnored(EntityType.CLIENT, "realm-a", "other-app"));
+        }
+    }
+
+    private static DiffCommandConfiguration configuration(final boolean includeBuiltIns,
+            final String ignoredExtras) {
+        return JsonUtil.fromJson("""
+                {
+                    "server": "http://localhost:8080",
+                    "username": "keycloak",
+                    "password": "root",
+                    "configDirectory": "./configuration",
+                    "flatFiles": false,
+                    "includeBuiltIns": %s,
+                    "ignoredExtras": %s
+                }
+                """.formatted(Boolean.valueOf(includeBuiltIns), ignoredExtras),
+                DiffCommandConfiguration.class);
+    }
+}

--- a/src/test/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffCommandTest.java
+++ b/src/test/java/com/cycrilabs/keycloak/configurator/commands/diff/control/DiffCommandTest.java
@@ -1,0 +1,91 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@Order(3)
+@QuarkusMainTest
+class DiffCommandTest {
+    @Test
+    @Launch(value = "diff", exitCode = 2)
+    public void shouldError_MissingParameters(final LaunchResult result) {
+        Assertions.assertTrue(result.getErrorOutput().contains("Missing required options"));
+    }
+
+    @Test
+    @Launch(value = { "diff", "-h" })
+    public void shouldPrintHelp(final LaunchResult result) {
+        final String output = result.getOutput();
+        Assertions.assertTrue(output.contains("--flat-files"));
+        Assertions.assertTrue(output.contains("--include-built-ins"));
+        Assertions.assertTrue(output.contains("--ignore-extra"));
+    }
+
+    /**
+     * An unreachable server must not be reported as a configuration that is missing on the
+     * server, as those are entirely different problems.
+     */
+    @Test
+    @Launch(value = { "diff", "-s", "http://localhost:1", "-u", "keycloak", "-p", "root", "-c",
+            "./src/test/resources/configuration-missing" }, exitCode = 3)
+    public void shouldFail_ServerIsUnreachable(final LaunchResult result) {
+        final String output = result.getOutput();
+
+        Assertions.assertTrue(output.contains("Could not authenticate against server"));
+        Assertions.assertFalse(output.contains("MISSING on server"));
+        Assertions.assertFalse(output.contains("differences across"));
+    }
+
+    /**
+     * Compares a configuration whose realm does not exist on the server. This is independent of
+     * the entities any other test creates, so the reported differences are deterministic.
+     */
+    @Test
+    @Launch(value = { "diff", "-s", "http://localhost:8080", "-u", "keycloak", "-p", "root", "-c",
+            "./src/test/resources/configuration-missing" }, exitCode = 1)
+    public void shouldReportMissingEntities_RealmDoesNotExistOnServer(final LaunchResult result) {
+        final String output = result.getOutput();
+
+        Assertions.assertTrue(output.contains("The server is not modified."));
+        Assertions.assertTrue(output.contains("Executing differ 'RealmDiffer'"));
+        Assertions.assertTrue(output.contains("Executing differ 'ComponentDiffer'"));
+
+        Assertions.assertTrue(output.contains("=== realm-unknown ==="));
+        Assertions.assertTrue(output.contains("realm 'realm-unknown'"));
+        Assertions.assertTrue(output.contains("MISSING on server"));
+    }
+
+    /**
+     * The flat file layout must be read by the 'diff' command as well.
+     */
+    @Test
+    @Launch(value = { "diff", "-s", "http://localhost:8080", "-u", "keycloak", "-p", "root", "-c",
+            "./src/test/resources/configuration-missing-flat", "--flat-files" }, exitCode = 1)
+    public void shouldReadFlatFileLayout(final LaunchResult result) {
+        final String output = result.getOutput();
+
+        Assertions.assertTrue(output.contains("Using 'FlatFileConfigurationFileLoader'"));
+        Assertions.assertTrue(output.contains("realm 'realm-unknown'"));
+        Assertions.assertTrue(output.contains("MISSING on server"));
+    }
+
+    /**
+     * Comparing a single entity type must not report findings of any other type.
+     */
+    @Test
+    @Launch(value = { "diff", "-s", "http://localhost:8080", "-u", "keycloak", "-p", "root", "-c",
+            "./src/test/resources/configuration-missing", "-t", "realm" }, exitCode = 1)
+    public void shouldOnlyCompareGivenEntityType(final LaunchResult result) {
+        final String output = result.getOutput();
+
+        Assertions.assertTrue(output.contains("Executing differ 'RealmDiffer'"));
+        Assertions.assertFalse(output.contains("Executing differ 'ClientDiffer'"));
+        Assertions.assertTrue(output.contains("realm 'realm-unknown'"));
+        Assertions.assertFalse(output.contains("client 'unknown-client'"));
+    }
+}

--- a/src/test/java/com/cycrilabs/keycloak/configurator/commands/diff/control/JsonDiffEngineTest.java
+++ b/src/test/java/com/cycrilabs/keycloak/configurator/commands/diff/control/JsonDiffEngineTest.java
@@ -1,0 +1,325 @@
+package com.cycrilabs.keycloak.configurator.commands.diff.control;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.FieldDifference;
+import com.cycrilabs.keycloak.configurator.commands.diff.entity.FieldDifferenceKind;
+import com.cycrilabs.keycloak.configurator.shared.control.JsonUtil;
+
+class JsonDiffEngineTest {
+    private static final Set<String> GENERATED_IDENTIFIERS = Set.of("id", "containerId");
+
+    @Nested
+    class DeclaredFieldTests {
+        @Test
+        void shouldOnlyCompareLocallyDeclaredFields() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "clientId": "blog",
+                        "enabled": true
+                    }
+                    """, """
+                    {
+                        "clientId": "blog",
+                        "enabled": false,
+                        "id": "6f1a",
+                        "secret": "server-secret",
+                        "nodeReRegistrationTimeout": -1
+                    }
+                    """);
+
+            assertSingleDifference(differences, "enabled", FieldDifferenceKind.VALUE_DIFFERENT,
+                    "true", "false");
+        }
+
+        @Test
+        void shouldReportField_NotSetOnServer() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "description": "Create posts"
+                    }
+                    """, "{ }");
+
+            assertSingleDifference(differences, "description",
+                    FieldDifferenceKind.MISSING_ON_SERVER, "\"Create posts\"", null);
+        }
+
+        @Test
+        void shouldNotReportDifference_FieldIsNullLocally() {
+            // A configuration file exported from a server contains many null fields. They declare
+            // nothing, so there is nothing to compare.
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "description": null
+                    }
+                    """, "{ }");
+
+            Assertions.assertTrue(differences.isEmpty());
+        }
+
+        @Test
+        void shouldCompareNestedObjects() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "attributes": { "a": "1" }
+                    }
+                    """, """
+                    {
+                        "attributes": { "a": "2", "b": "3" }
+                    }
+                    """);
+
+            assertSingleDifference(differences, "attributes.a",
+                    FieldDifferenceKind.VALUE_DIFFERENT, "\"1\"", "\"2\"");
+        }
+
+        @Test
+        void shouldReportDifference_TypeOfFieldChanged() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "attributes": { "a": "1" }
+                    }
+                    """, """
+                    {
+                        "attributes": "not-an-object"
+                    }
+                    """);
+
+            assertSingleDifference(differences, "attributes",
+                    FieldDifferenceKind.VALUE_DIFFERENT, "{\"a\":\"1\"}", "\"not-an-object\"");
+        }
+    }
+
+    @Nested
+    class CollectionTests {
+        @Test
+        void shouldCompareCollectionOfValuesAsSet_BothDirections() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "redirectUris": [ "https://a", "https://b" ]
+                    }
+                    """, """
+                    {
+                        "redirectUris": [ "https://b", "https://c" ]
+                    }
+                    """);
+
+            Assertions.assertEquals(2, differences.size());
+            assertContains(differences, "redirectUris", FieldDifferenceKind.ONLY_IN_LOCAL,
+                    "[https://a]", null);
+            assertContains(differences, "redirectUris", FieldDifferenceKind.ONLY_ON_SERVER, null,
+                    "[https://c]");
+        }
+
+        @Test
+        void shouldNotReportDifference_OnlyOrderOfCollectionDiffers() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "redirectUris": [ "https://a", "https://b" ]
+                    }
+                    """, """
+                    {
+                        "redirectUris": [ "https://b", "https://a" ]
+                    }
+                    """);
+
+            Assertions.assertTrue(differences.isEmpty());
+        }
+
+        @Test
+        void shouldReportDifference_DeclaredCollectionIsEmptyLocally() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "redirectUris": []
+                    }
+                    """, """
+                    {
+                        "redirectUris": [ "https://a" ]
+                    }
+                    """);
+
+            assertSingleDifference(differences, "redirectUris",
+                    FieldDifferenceKind.ONLY_ON_SERVER, null, "[https://a]");
+        }
+
+        @Test
+        void shouldMatchCollectionOfObjectsByName() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "protocolMappers": [
+                            { "name": "audience", "consentRequired": false }
+                        ]
+                    }
+                    """, """
+                    {
+                        "protocolMappers": [
+                            { "name": "audience", "consentRequired": true, "id": "6f1a" },
+                            { "name": "locale" }
+                        ]
+                    }
+                    """);
+
+            Assertions.assertEquals(2, differences.size());
+            assertContains(differences, "protocolMappers[audience].consentRequired",
+                    FieldDifferenceKind.VALUE_DIFFERENT, "false", "true");
+            assertContains(differences, "protocolMappers", FieldDifferenceKind.ONLY_ON_SERVER, null,
+                    "[locale]");
+        }
+    }
+
+    @Nested
+    class ValueComparisonTests {
+        @Test
+        void shouldNotReportDifference_NumbersOfDifferentJsonTypeHoldSameValue() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "notBefore": 1,
+                        "accessTokenLifespan": 300
+                    }
+                    """, """
+                    {
+                        "notBefore": 1.0,
+                        "accessTokenLifespan": 300
+                    }
+                    """);
+
+            Assertions.assertTrue(differences.isEmpty());
+        }
+
+        @Test
+        void shouldNotReportDifference_BooleanIsWrittenAsText() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "enabled": "true"
+                    }
+                    """, """
+                    {
+                        "enabled": true
+                    }
+                    """);
+
+            Assertions.assertTrue(differences.isEmpty());
+        }
+    }
+
+    @Nested
+    class IgnoredFieldTests {
+        @Test
+        void shouldIgnoreGeneratedIdentifiers_AtAnyDepth() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "id": "local-id",
+                        "protocolMappers": [ { "name": "audience", "id": "local-mapper-id" } ]
+                    }
+                    """, """
+                    {
+                        "id": "server-id",
+                        "protocolMappers": [ { "name": "audience", "id": "server-mapper-id" } ]
+                    }
+                    """);
+
+            Assertions.assertTrue(differences.isEmpty());
+        }
+
+        @Test
+        void shouldIgnoreExactPathOnly_FullPathGiven() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "config": { "bindDn": "cn=local" },
+                        "bindDn": "cn=local-root"
+                    }
+                    """, """
+                    {
+                        "config": { "bindDn": "cn=server" },
+                        "bindDn": "cn=server-root"
+                    }
+                    """, Set.of("config.bindDn"));
+
+            assertSingleDifference(differences, "bindDn", FieldDifferenceKind.VALUE_DIFFERENT,
+                    "\"cn=local-root\"", "\"cn=server-root\"");
+        }
+    }
+
+    @Nested
+    class RedactionTests {
+        @Test
+        void shouldRedactSensitiveValues_ButStillReportDifference() {
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "secret": "local-secret",
+                        "config": { "bindCredential": [ "local-password" ] }
+                    }
+                    """, """
+                    {
+                        "secret": "server-secret",
+                        "config": { "bindCredential": [ "server-password" ] }
+                    }
+                    """);
+
+            Assertions.assertEquals(3, differences.size());
+            assertContains(differences, "secret", FieldDifferenceKind.VALUE_DIFFERENT, "<redacted>",
+                    "<redacted>");
+            assertContains(differences, "config.bindCredential",
+                    FieldDifferenceKind.ONLY_IN_LOCAL, "<redacted>", null);
+            assertContains(differences, "config.bindCredential",
+                    FieldDifferenceKind.ONLY_ON_SERVER, null, "<redacted>");
+            differences.forEach(difference -> {
+                Assertions.assertFalse(String.valueOf(difference.localValue())
+                        .contains("local-password"));
+                Assertions.assertFalse(String.valueOf(difference.serverValue())
+                        .contains("server-password"));
+            });
+        }
+
+        @Test
+        void shouldRedactSensitiveValues_NestedInRenderedObject() {
+            // The whole credential is rendered because it has no counterpart on the server.
+            final List<FieldDifference> differences = compare("""
+                    {
+                        "credentials": [ { "type": "password", "value": "hunter2" } ]
+                    }
+                    """, """
+                    {
+                        "credentials": []
+                    }
+                    """);
+
+            assertSingleDifference(differences, "credentials", FieldDifferenceKind.ONLY_IN_LOCAL,
+                    "{\"type\":\"password\",\"value\":\"<redacted>\"}", null);
+        }
+    }
+
+    private static List<FieldDifference> compare(final String local, final String server) {
+        return compare(local, server, GENERATED_IDENTIFIERS);
+    }
+
+    private static List<FieldDifference> compare(final String local, final String server,
+            final Set<String> ignoredPaths) {
+        final List<FieldDifference> differences = new ArrayList<>();
+        JsonDiffEngine.compare(JsonUtil.readTree(local), JsonUtil.readTree(server), ignoredPaths,
+                differences::add);
+        return differences;
+    }
+
+    private static void assertSingleDifference(final List<FieldDifference> differences,
+            final String path, final FieldDifferenceKind kind, final String localValue,
+            final String serverValue) {
+        Assertions.assertEquals(1, differences.size(), () -> "Expected one difference but got "
+                + differences);
+        assertContains(differences, path, kind, localValue, serverValue);
+    }
+
+    private static void assertContains(final List<FieldDifference> differences, final String path,
+            final FieldDifferenceKind kind, final String localValue, final String serverValue) {
+        final FieldDifference expected =
+                new FieldDifference(path, kind, localValue, serverValue);
+        Assertions.assertTrue(differences.contains(expected),
+                () -> "Expected " + expected + " in " + differences);
+    }
+}

--- a/src/test/resources/configuration-missing-flat/realm-unknown/clients_unknown-client.json
+++ b/src/test/resources/configuration-missing-flat/realm-unknown/clients_unknown-client.json
@@ -1,0 +1,5 @@
+{
+    "clientId": "unknown-client",
+    "enabled": true,
+    "protocol": "openid-connect"
+}

--- a/src/test/resources/configuration-missing-flat/realm-unknown/realms_realm-unknown.json
+++ b/src/test/resources/configuration-missing-flat/realm-unknown/realms_realm-unknown.json
@@ -1,0 +1,5 @@
+{
+    "realm": "realm-unknown",
+    "displayName": "Unknown Realm",
+    "enabled": true
+}

--- a/src/test/resources/configuration-missing/realm-unknown/clients/unknown-client.json
+++ b/src/test/resources/configuration-missing/realm-unknown/clients/unknown-client.json
@@ -1,0 +1,5 @@
+{
+    "clientId": "unknown-client",
+    "enabled": true,
+    "protocol": "openid-connect"
+}

--- a/src/test/resources/configuration-missing/realm-unknown/realms/realm-unknown.json
+++ b/src/test/resources/configuration-missing/realm-unknown/realms/realm-unknown.json
@@ -1,0 +1,5 @@
+{
+    "realm": "realm-unknown",
+    "displayName": "Unknown Realm",
+    "enabled": true
+}


### PR DESCRIPTION
Adds a `diff` sub-command that reports all differences between a Keycloak
instance and the local configuration. The server is only read, never modified.

Only fields that a configuration file actually declares are compared — such a
file is a partial description of an entity, so fields only the server knows
(generated ids, secrets, Keycloak defaults) are not differences. Entities that
exist only on the server are reported too, filtered by a list of Keycloak
built-ins (`--include-built-ins` to see them, `--ignore-extra` to add your own).

Exit codes make it usable as a drift check: `0` in sync, `1` differences found,
`2` called incorrectly, `3` server unreachable — the latter so a bad URL or
credentials is not mistaken for a configuration that was never applied.

### Review

The first two commits are prerequisite refactors of `configure` with no
behaviour change; the remaining five add the feature. Best reviewed in order —
each commit compiles on its own.

Verify with `./cli.sh --start && mvn -Pgithub test` (48 tests). The `configure`,
`rotate-secrets` and `diff` tests need that running Keycloak.

Note: running this against the repo's own test fixture surfaces a pre-existing
issue — `service-account-realm-roles/service-account-blog` declares
`posts-create`, which is a client role of `blog`, not a realm role, so
`configure` silently drops it.
